### PR TITLE
fix: restore fragment link icon using sprite system

### DIFF
--- a/app/(post)/blog/[...slug]/post.module.css
+++ b/app/(post)/blog/[...slug]/post.module.css
@@ -218,24 +218,22 @@
     display: inline-block;
     vertical-align: text-top;
     transform-origin: center center;
-    mix-blend-mode: multiply;
 
     @media (width >= 640px) {
       top: 0.025em;
     }
   }
 
-  & :global(.fragment .icon:before) {
-    content: url(/icon/16/link.svg);
+  & :global(.fragment svg.icon) {
     display: block;
     width: 16px;
     height: 16px;
     margin-inline-end: 0.25rem;
     margin-inline-start: calc(-0.25rem - 16px);
     opacity: 0.4;
+    color: inherit;
 
     @media (width >= 640px) {
-      content: url(/icon/24/link.svg);
       width: 24px;
       height: 24px;
       margin-inline-end: 0.5rem;

--- a/contentlayer.config.js
+++ b/contentlayer.config.js
@@ -309,6 +309,27 @@ export default makeSource({
             ariaHidden: true,
             tabIndex: -1,
           },
+          content: {
+            type: 'element',
+            tagName: 'svg',
+            properties: {
+              width: 16,
+              height: 16,
+              viewBox: '0 0 16 16',
+              ariaHidden: 'true',
+              className: ['icon'],
+            },
+            children: [
+              {
+                type: 'element',
+                tagName: 'use',
+                properties: {
+                  href: '#link-16',
+                },
+                children: [],
+              },
+            ],
+          },
         },
       ],
       [rehypePrism, { ignoreMissing: true }],


### PR DESCRIPTION
Replace CSS pseudo-element `content: url()` approach with an inline SVG injected via rehypeAutolinkHeadings `content` option. Also removes `mix-blend-mode: multiply` which caused the icon to be invisible in dark mode.

Fixes #222

Generated with [Claude Code](https://claude.ai/code)