### PR TITLE
Update new-note skill to skip branch creation in cloud sessions

### DIFF
--- a/.claude/skills/new-note/SKILL.md
+++ b/.claude/skills/new-note/SKILL.md
@@ -6,7 +6,9 @@ allowed-tools: Bash
 
 Create a new note for the blog by doing the following in order:
 
-1. Run `git checkout -b note-$(date +%Y-%m-%d)` to create and switch to a new branch
+1. Check the current branch name with `git branch --show-current`
+   - If the branch starts with `claude/` (cloud session), skip branch creation and stay on the current branch
+   - Otherwise, run `git checkout -b note-$(date +%Y-%m-%d)` to create and switch to a new branch
 2. Run `node scripts/compose-note.js` to scaffold the note file via the interactive prompt
 
-Once done, confirm the branch name that was created.
+Once done, confirm the branch name and whether a new branch was created or an existing one was used.


### PR DESCRIPTION
Detects cloud sessions by checking if the current branch starts with
claude/. When in a cloud session, the skill stays on the assigned
branch instead of creating a note-dated branch that can't be pushed.

https://claude.ai/code/session_015eRhFU2kMQ8QCom2YAUKLi