### PR TITLE
fix: preserve straight quotes in chat blocks

### DIFF
--- a/contentlayer.config.js
+++ b/contentlayer.config.js
@@ -299,7 +299,7 @@ export default makeSource({
   contentDirExclude: ['./content/draft'],
   documentTypes: [Post, Page, Collections, Note],
   mdx: {
-    remarkPlugins: [remarkGfm, remarkCodeTitles, remarkChat, smartypants],
+    remarkPlugins: [remarkGfm, remarkCodeTitles, smartypants, remarkChat],
     rehypePlugins: [
       rehypeSlug,
       [


### PR DESCRIPTION
Swap plugin order so smartypants runs before remarkChat, preserving straight quotes in chat code blocks.

Closes #233

Generated with [Claude Code](https://claude.ai/code)