### PR TITLE
fix: close mobile nav on route change

### DIFF
--- a/components/navigation.js
+++ b/components/navigation.js
@@ -1,5 +1,5 @@
 'use client'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { usePathname } from 'next/navigation'
 import { DialogTrigger, Button, Popover } from 'react-aria-components'
 import clsx from 'clsx'
@@ -31,6 +31,10 @@ const Toggle = () => {
 const Navigation = () => {
   const [isOpen, setIsOpen] = useState(false)
   const pathname = usePathname()
+
+  useEffect(() => {
+    setIsOpen(false)
+  }, [pathname])
 
   return (
     <DialogTrigger isOpen={isOpen} onOpenChange={setIsOpen}>


### PR DESCRIPTION
Closes #242

Add a `useEffect` to reset `isOpen` when `pathname` changes, so the mobile navigation menu closes automatically after tapping a link.

Generated with [Claude Code](https://claude.ai/code)