### PR TITLE
Add internal cross-links between typography and Illustrator posts

### DIFF
--- a/content/blog/0130-illustrator-quick-tip-align-to-key-object.md
+++ b/content/blog/0130-illustrator-quick-tip-align-to-key-object.md
@@ -39,3 +39,5 @@ Using align to key object is a quick method for aligning horizontally or vertica
 ## That’s it
 
 I do wish there was a way to somehow default this behaviour. Taking the item in the back as the key object, this would work well. Anyway, I felt this was a necessary quick tip to highlight, as I’ve found it valuable.
+
+Once you’re comfortable with this, it’s also the key to [evenly spacing objects](/blog/illustrator-quick-tip-equally-space-objects) with a precise pixel value.

--- a/content/blog/0176-rules-i-follow-when-typesetting.md
+++ b/content/blog/0176-rules-i-follow-when-typesetting.md
@@ -156,7 +156,7 @@ Like line height, I don’t think you can apply a simple percentage rule to any 
   <figcaption><p><Fig>5</Fig> Shows the difference between the heading with tracking on and off</p></figcaption>
 </figure>
 
-It takes a little tweaking depending on the typeface you’re using. Think of a display typeface versus a text typeface. Using them at varying sizes will require different extremes of tracking.
+It takes a little tweaking depending on the typeface you’re using. Think of a display typeface versus a text typeface. Using them at varying sizes will require different extremes of tracking. Typefaces with [ink traps](/blog/the-best-ink-trap-typefaces-for-websites), for example, tend to be designed for display use and benefit from tighter tracking at large sizes.
 
 ## Everything is sentence case
 Everything, whether that is a heading, button, navigation link or whatever else you can think of. It’s sentence case—no exceptions.


### PR DESCRIPTION
- Typesetting post: link to ink trap post from tracking/display typeface discussion
- Align to key object: link to equally space objects as a natural next step

https://claude.ai/code/session_012v4ANANeB8oicJYTKiGesJ