### PR TITLE
Optimize release action to avoid double Vercel builds

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,24 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - github-actions[bot]
+  categories:
+    - title: "New features"
+      labels:
+        - feature
+        - enhancement
+    - title: "Bug fixes"
+      labels:
+        - bug
+        - fix
+    - title: "Design"
+      labels:
+        - design
+    - title: "Content"
+      labels:
+        - content
+    - title: "Other changes"
+      labels:
+        - "*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump type"
+        required: true
+        type: choice
+        options:
+          - major
+          - minor
 
 jobs:
   release:
@@ -49,20 +58,15 @@ jobs:
         if: steps.changes.outputs.skip == 'false'
         id: bump_type
         run: |
-          LATEST_TAG="${{ steps.latest_tag.outputs.tag }}"
-          MSGS=$(git log ${LATEST_TAG}..HEAD --pretty=%s)
-
-          echo "Checking messages for version bump type..."
-
-          # Major: explicit breaking change
-          if echo "$MSGS" | grep -qE "(^major:|major!:|BREAKING CHANGE|\[major\])"; then
-            echo "type=major" >> $GITHUB_OUTPUT
-            echo "Detected: MAJOR bump"
-          # Minor: features
-          elif echo "$MSGS" | grep -qiE "(feat/|feature/|feat:|feat\()"; then
+          # Major and minor are manual only (via workflow dispatch)
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "type=${{ inputs.bump }}" >> $GITHUB_OUTPUT
+            echo "Manual bump: ${{ inputs.bump }}"
+          # Features get a minor bump
+          elif git log ${{ steps.latest_tag.outputs.tag }}..HEAD --pretty=%s | grep -qiE "(feat/|feature/|feat:|feat\()"; then
             echo "type=minor" >> $GITHUB_OUTPUT
             echo "Detected: MINOR bump"
-          # Patch: everything else
+          # Everything else is a patch
           else
             echo "type=patch" >> $GITHUB_OUTPUT
             echo "Detected: PATCH bump"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # Skip version bump commits from this workflow
+    if: "!startsWith(github.event.head_commit.message, 'chore: bump version')"
     permissions:
       contents: write
 
@@ -16,63 +18,66 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Configure git
+      - name: Get latest tag
+        id: latest_tag
         run: |
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          echo "tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+          echo "Latest tag: $LATEST_TAG"
 
-      - name: Get current version
-        id: current_version
+      - name: Check for meaningful changes
+        id: changes
         run: |
-          CURRENT_VERSION=$(node -p "require('./package.json').version")
-          echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          LATEST_TAG="${{ steps.latest_tag.outputs.tag }}"
 
-      - name: Determine version bump type
-        id: bump_type
-        run: |
-          # Get the merge commit message (includes branch name for PR merges)
-          MERGE_MSG=$(git log -1 --pretty=%B)
+          # Get PR titles and commit messages since the last tag
+          MSGS=$(git log ${LATEST_TAG}..HEAD --pretty=%s)
 
-          # Get all commit messages since last tag (for squash merges)
-          LAST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -n "$LAST_TAG" ]; then
-            COMMIT_MSGS=$(git log ${LAST_TAG}..HEAD --pretty=%B)
+          echo "Commits since ${LATEST_TAG}:"
+          echo "$MSGS"
+
+          # Skip release if the only commits are version bumps or empty
+          MEANINGFUL=$(echo "$MSGS" | grep -cvE "^(chore: bump version|Merge branch)" || true)
+          if [ "$MEANINGFUL" -eq 0 ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "No meaningful changes, skipping release"
           else
-            COMMIT_MSGS=$(git log -10 --pretty=%B)
+            echo "skip=false" >> $GITHUB_OUTPUT
           fi
 
-          # Combine both for checking
-          ALL_MSGS="$MERGE_MSG $COMMIT_MSGS"
+      - name: Determine version bump type
+        if: steps.changes.outputs.skip == 'false'
+        id: bump_type
+        run: |
+          LATEST_TAG="${{ steps.latest_tag.outputs.tag }}"
+          MSGS=$(git log ${LATEST_TAG}..HEAD --pretty=%s)
 
           echo "Checking messages for version bump type..."
-          echo "$ALL_MSGS"
 
-          # Check for breaking changes (major) - requires explicit "major" keyword
-          if echo "$ALL_MSGS" | grep -qE "(^major:|major!:|BREAKING CHANGE|\[major\])"; then
+          # Major: explicit breaking change
+          if echo "$MSGS" | grep -qE "(^major:|major!:|BREAKING CHANGE|\[major\])"; then
             echo "type=major" >> $GITHUB_OUTPUT
             echo "Detected: MAJOR bump"
-          # Check for features (minor)
-          elif echo "$ALL_MSGS" | grep -qiE "(feat/|feature/|feat:|feat\()"; then
+          # Minor: features
+          elif echo "$MSGS" | grep -qiE "(feat/|feature/|feat:|feat\()"; then
             echo "type=minor" >> $GITHUB_OUTPUT
             echo "Detected: MINOR bump"
-          # Default to patch
+          # Patch: everything else
           else
             echo "type=patch" >> $GITHUB_OUTPUT
             echo "Detected: PATCH bump"
           fi
-      - name: Bump version
-        id: bump_version
+
+      - name: Calculate new version
+        if: steps.changes.outputs.skip == 'false'
+        id: new_version
         run: |
-          IFS='.' read -r MAJOR MINOR PATCH <<< "${{ steps.current_version.outputs.version }}"
+          VERSION="${{ steps.latest_tag.outputs.tag }}"
+          VERSION="${VERSION#v}"
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
           BUMP_TYPE="${{ steps.bump_type.outputs.type }}"
 
-          # Calculate new version based on bump type
           case "$BUMP_TYPE" in
             major)
               NEW_VERSION="$((MAJOR + 1)).0.0"
@@ -85,22 +90,22 @@ jobs:
               ;;
           esac
 
-          echo "Current version: ${{ steps.current_version.outputs.version }}"
-          echo "Bump type: $BUMP_TYPE"
-          echo "New version: $NEW_VERSION"
-          echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
-          npm version $NEW_VERSION --no-git-tag-version
+          echo "version=$NEW_VERSION" >> $GITHUB_OUTPUT
+          echo "${{ steps.latest_tag.outputs.tag }} → v${NEW_VERSION} (${BUMP_TYPE})"
 
-      - name: Commit version bump
-        run: |
-          git add package.json
-          git commit -m "chore: bump version to ${{ steps.bump_version.outputs.new_version }}"
-          git push
-
-      - name: Create GitHub release
+      - name: Create tag and release
+        if: steps.changes.outputs.skip == 'false'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release create "v${{ steps.bump_version.outputs.new_version }}" \
-            --title "v${{ steps.bump_version.outputs.new_version }}" \
-            --generate-notes
+          NEW_TAG="v${{ steps.new_version.outputs.version }}"
+
+          # Tag the current commit (the merge commit) directly
+          git tag "$NEW_TAG"
+          git push origin "$NEW_TAG"
+
+          # Create release with auto-generated notes grouped by .github/release.yml
+          gh release create "$NEW_TAG" \
+            --title "$NEW_TAG" \
+            --generate-notes \
+            --latest

--- a/README.md
+++ b/README.md
@@ -222,29 +222,20 @@ When a PR is merged to `main`, the release action automatically:
 This means **one merge = one Vercel build**, not two.
 
 ### Version bump rules
-The version bump is determined by your commit messages or branch names. Use the following patterns to control which type of release is created:
 
-**Major** (breaking changes, e.g. `v9.0.0` &rarr; `v10.0.0`):
-```
-major: redesign navigation
-BREAKING CHANGE: remove legacy API
-[major] overhaul theme system
-```
+**Patch** (automatic &mdash; the default, e.g. `v9.0.0` &rarr; `v9.0.1`):
+Most merges create a patch release. Bug fixes, content updates, design tweaks, and chores all fall into this category.
 
-**Minor** (new features, e.g. `v9.0.0` &rarr; `v9.1.0`):
+**Minor** (automatic for features, e.g. `v9.0.0` &rarr; `v9.1.0`):
+Triggered when commit messages or branch names include `feat:`, `feat/`, or `feature/`:
 ```
 feat: add search to blog
 feat(collections): filter by tag
 ```
 Or use a branch name like `feat/search` or `feature/dark-mode`.
 
-**Patch** (bug fixes, content, design tweaks &mdash; the default, e.g. `v9.0.0` &rarr; `v9.0.1`):
-```
-fix: broken link on homepage
-chore: update dependencies
-post/new-blog-post
-```
-Everything that doesn't match major or minor patterns is a patch.
+**Major** (manual only, e.g. `v9.0.0` &rarr; `v10.0.0`):
+Major versions are reserved for significant milestones like a full redesign or framework migration. To create one, trigger the release workflow manually from the Actions tab and select "major" as the bump type.
 
 ### Release note categories
 Release notes are grouped by PR labels (configured in `.github/release.yml`):

--- a/README.md
+++ b/README.md
@@ -207,6 +207,44 @@ This ensures newly imported items are highlighted until you perform another impo
 
 </details>
 
+## Releases and versioning
+<details>
+<summary>How releases are created automatically</summary>
+
+### How it works
+When a PR is merged to `main`, the release action automatically:
+1. Finds the latest git tag (e.g. `v9.0.0`)
+2. Checks if there are meaningful changes since that tag
+3. Determines the version bump type from commit messages
+4. Tags the merge commit directly (no extra commit pushed to `main`)
+5. Creates a GitHub release with grouped release notes
+
+This means **one merge = one Vercel build**, not two.
+
+### Version bump rules
+| Commit message pattern | Bump | Example |
+|---|---|---|
+| `major:`, `BREAKING CHANGE`, `[major]` | Major | `v9.0.0` &rarr; `v10.0.0` |
+| `feat:`, `feat/`, `feature/` | Minor | `v9.0.0` &rarr; `v9.1.0` |
+| Everything else | Patch | `v9.0.0` &rarr; `v9.0.1` |
+
+### Release note categories
+Release notes are grouped by PR labels (configured in `.github/release.yml`):
+- **New features** &mdash; `feature`, `enhancement`
+- **Bug fixes** &mdash; `bug`, `fix`
+- **Design** &mdash; `design`
+- **Content** &mdash; `content`
+- **Other changes** &mdash; everything else
+
+PRs labelled `skip-changelog` and commits from `github-actions[bot]` are excluded.
+
+### Checking out a past version
+Every release is tagged, so you can check out any version:
+```bash
+git checkout v8.2.0
+```
+</details>
+
 ## Credits
 <details>
 <summary>Acknowledgements</summary>

--- a/README.md
+++ b/README.md
@@ -222,11 +222,29 @@ When a PR is merged to `main`, the release action automatically:
 This means **one merge = one Vercel build**, not two.
 
 ### Version bump rules
-| Commit message pattern | Bump | Example |
-|---|---|---|
-| `major:`, `BREAKING CHANGE`, `[major]` | Major | `v9.0.0` &rarr; `v10.0.0` |
-| `feat:`, `feat/`, `feature/` | Minor | `v9.0.0` &rarr; `v9.1.0` |
-| Everything else | Patch | `v9.0.0` &rarr; `v9.0.1` |
+The version bump is determined by your commit messages or branch names. Use the following patterns to control which type of release is created:
+
+**Major** (breaking changes, e.g. `v9.0.0` &rarr; `v10.0.0`):
+```
+major: redesign navigation
+BREAKING CHANGE: remove legacy API
+[major] overhaul theme system
+```
+
+**Minor** (new features, e.g. `v9.0.0` &rarr; `v9.1.0`):
+```
+feat: add search to blog
+feat(collections): filter by tag
+```
+Or use a branch name like `feat/search` or `feature/dark-mode`.
+
+**Patch** (bug fixes, content, design tweaks &mdash; the default, e.g. `v9.0.0` &rarr; `v9.0.1`):
+```
+fix: broken link on homepage
+chore: update dependencies
+post/new-blog-post
+```
+Everything that doesn't match major or minor patterns is a patch.
 
 ### Release note categories
 Release notes are grouped by PR labels (configured in `.github/release.yml`):


### PR DESCRIPTION
- Tag the merge commit directly instead of committing a version bump back to main
- Derive version from the latest git tag, not package.json
- Add .github/release.yml to group release notes by PR labels
- Skip releases when there are no meaningful changes

https://claude.ai/code/session_01HhXwugJ6QhxkMugDH8m7Fb