### PR TITLE
Fix broken link in vj-type-16-dahlia

### DIFF
--- a/content/collections/vj-type-16-dahlia.md
+++ b/content/collections/vj-type-16-dahlia.md
@@ -1,6 +1,6 @@
 ---
 title: VJ Type
-url: https://vj-type.com/16-dahlia
+url: https://vj-type.com
 date: "2025-12-06T18:47:01.796Z"
 collection:
   - Foundry


### PR DESCRIPTION
Updates the URL in `content/collections/vj-type-16-dahlia.md` from the 404 `https://vj-type.com/16-dahlia` to `https://vj-type.com`.

Closes #286

Generated with [Claude Code](https://claude.ai/code)