### PR TITLE
Restrict collections validation to PRs targeting main

### DIFF
--- a/.github/workflows/validate-collection-links.yml
+++ b/.github/workflows/validate-collection-links.yml
@@ -2,6 +2,8 @@ name: Validate Collection Links
 
 on:
   pull_request:
+    branches:
+      - main
     paths:
       - 'content/collections/**'
   workflow_dispatch:


### PR DESCRIPTION
The pull_request trigger now only fires for PRs targeting main,
preventing unnecessary runs on feature branches. Schedule and
workflow_dispatch already default to the main branch.

https://claude.ai/code/session_011MyA6ixbL87hgL4NjhJkW6