### PR TITLE
Add unlisted status for posts accessible by URL and sitemap but hidden from listings

### DIFF
--- a/app/(post)/blog/[...slug]/page.js
+++ b/app/(post)/blog/[...slug]/page.js
@@ -48,7 +48,7 @@ import styles from './post.module.css'
 
 export async function generateStaticParams() {
   return allPosts
-    .filter((post) => post.status === 'open')
+    .filter((post) => post.status === 'open' || post.status === 'unlisted')
     .map((post) => ({
       slug: post.slugAsParams.split('/'),
     }))
@@ -59,7 +59,9 @@ async function getPostFromParams(params, showDrafts = false) {
   const slug = params?.slug?.join('/')
   const post = allPosts.find((post) => {
     const slugMatch = post.slugAsParams === slug
-    const statusMatch = showDrafts ? true : post.status === 'open'
+    const statusMatch = showDrafts
+      ? true
+      : post.status === 'open' || post.status === 'unlisted'
     return slugMatch && statusMatch
   })
 

--- a/app/sitemap.js
+++ b/app/sitemap.js
@@ -3,7 +3,10 @@ import { allPosts, allNotes } from 'content-collections'
 
 export default async function generateSitemap() {
   let posts = allPosts
-    .filter((post) => post.status === 'open' && !post.noindex)
+    .filter(
+      (post) =>
+        (post.status === 'open' || post.status === 'unlisted') && !post.noindex
+    )
     .map((post) => ({
       url: `${siteMetadata.siteUrl}${post.slug}`,
       lastModified: post.lastmod,

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -127,7 +127,7 @@ const posts = defineCollection({
     codepen: z.boolean().optional(),
     twitter: z.boolean().optional(),
     id: z.number(),
-    status: z.enum(['draft', 'open', 'closed']).default('draft'),
+    status: z.enum(['draft', 'open', 'closed', 'unlisted']).default('draft'),
     noindex: z.boolean().optional(),
   }),
   transform: async (doc, ctx) => {

--- a/content/blog/0171-css-tip-avoid-your-font-face-fauxs.md
+++ b/content/blog/0171-css-tip-avoid-your-font-face-fauxs.md
@@ -8,7 +8,7 @@ theme: '#fffbf2'
 tags: ['Code', 'CSS']
 categories: ['Code', 'CSS']
 ogImage: '/assets/og/cover.jpg'
-status: 'closed'
+status: 'unlisted'
 id: 171
 fileroot: 'css-tip-avoid-your-font-face-fauxs'
 ---

--- a/content/blog/0171-css-tip-avoid-your-font-face-fauxs.md
+++ b/content/blog/0171-css-tip-avoid-your-font-face-fauxs.md
@@ -1,7 +1,7 @@
 ---
 title: 'Avoid your font face fauxs'
-date: '2024-02-19T08:11:37.767Z'
-lastmod: '2019-12-18T07:57:57+00:00'
+date: '2026-04-14T09:00:00.000Z'
+lastmod: '2026-04-14T09:00:00.000Z'
 summary: ‘Defining font weights as separate @font-face declarations is outdated and causes faux bold and italic issues. Here’s how to avoid it and do it correctly.’
 metadesc: 'A blog written by Steve McKinney, focused on designing with Illustrator and writing maintainable CSS.'
 theme: '#fffbf2'

--- a/content/blog/0174-about-version-8.md
+++ b/content/blog/0174-about-version-8.md
@@ -1,7 +1,7 @@
 ---
 title: About version 8
-date: 2024-02-29T10:13:38.269Z
-lastmod: 2024-02-29T10:13:38.269Z
+date: 2024-02-29T11:13:38.269Z
+lastmod: 2024-02-29T11:13:38.269Z
 summary: Design and development decisions for the 8th version of this website. New design, using Next.js App Router and pretty much all in on Tailwind.
 metadesc: Design and development decisions for the 8th version of this website. New design, using Next.js App Router and pretty much all in on Tailwind.
 theme: '#f9f3f1'


### PR DESCRIPTION
The font face fauxs article is now published as unlisted — accessible
by direct URL and included in the sitemap for indexing, but excluded
from the homepage, blog archive, category pages, and RSS feeds.

https://claude.ai/code/session_0144B13FFAmDHjZXcrUW9m3g