### PR TITLE
Fix mobile code block margin and border radius

### DIFF
--- a/app/(post)/blog/[...slug]/post.module.css
+++ b/app/(post)/blog/[...slug]/post.module.css
@@ -389,9 +389,10 @@
   & :global([data-rehype-pretty-code-figure]),
   & > :global(.shiki) {
     box-shadow: var(--shadow-placed);
-    margin-inline: -2.25rem;
+    margin-inline: -16px;
 
     @media (width >= 640px) {
+      margin-inline: -2.25rem;
       border-radius: var(--radius-lg);
       overflow: hidden;
     }

--- a/app/(post)/blog/[...slug]/post.module.css
+++ b/app/(post)/blog/[...slug]/post.module.css
@@ -282,7 +282,7 @@
     text-wrap: pretty;
   }
 
-  & figure :where(figcaption) {
+  & figure :where(figcaption:not([data-rehype-pretty-code-title])) {
     padding-block-start: var(--block-space-small);
   }
 
@@ -389,10 +389,8 @@
   & :global([data-rehype-pretty-code-figure]),
   & > :global(.shiki) {
     box-shadow: var(--shadow-placed);
-    margin-inline: -16px;
 
     @media (width >= 640px) {
-      margin-inline: -2.25rem;
       border-radius: var(--radius-lg);
       overflow: hidden;
     }

--- a/css/code.css
+++ b/css/code.css
@@ -203,10 +203,7 @@ code[data-line-numbers] {
     background-color: var(--code-bg);
     box-shadow: var(--shadow-placed);
     margin-block: calc(var(--spacing) * 8);
-
-    @media (width >= 640px) {
-      border-radius: var(--radius-lg);
-    }
+    border-radius: var(--radius-lg);
   }
 
   .codepen,
@@ -259,8 +256,6 @@ code[data-line-numbers] {
  * Prose-specific overrides (post bleed layout)
  */
 .prose {
-  [data-rehype-pretty-code-figure],
-  & > .shiki,
   .codepen,
   .codepen-wide {
     margin-inline: calc(var(--code-padding) * -1);

--- a/css/code.css
+++ b/css/code.css
@@ -240,8 +240,12 @@ code[data-line-numbers] {
   gap: calc(var(--spacing) * 2);
   background-color: var(--code-title-bg);
   box-shadow: inset 0 -1px 0 var(--code-border);
-  padding-inline: var(--code-padding);
+  padding-inline: calc(var(--spacing) * 2) var(--code-padding);
   padding-block: calc(var(--spacing) * 3);
+
+  @media (width >= 640px) {
+    padding-inline: var(--code-padding);
+  }
 }
 
 :is(.prose, .codeblock) [data-rehype-pretty-code-title] > span {

--- a/css/code.css
+++ b/css/code.css
@@ -200,10 +200,13 @@ code[data-line-numbers] {
   .codepen,
   .codepen-wide {
     overflow: auto;
-    border-radius: var(--radius-lg);
     background-color: var(--code-bg);
     box-shadow: var(--shadow-placed);
     margin-block: calc(var(--spacing) * 8);
+
+    @media (width >= 640px) {
+      border-radius: var(--radius-lg);
+    }
   }
 
   .codepen,


### PR DESCRIPTION
Reduce mobile negative margin on code blocks from -2.25rem to -16px
to match --code-padding, and move border-radius behind the 640px
breakpoint so code blocks sit flush without rounded corners on mobile.

https://claude.ai/code/session_01XNtF8aNUaNCmTT2MkqCesB