### PR TITLE
Serve homepage as markdown when agents request it

### DIFF
--- a/app/api/content/home/route.js
+++ b/app/api/content/home/route.js
@@ -1,0 +1,84 @@
+import { allPosts } from 'content-collections'
+import { createClient } from '@supabase/supabase-js'
+
+import siteMetadata from '@/content/metadata'
+
+export const revalidate = 86400
+export const dynamic = 'force-static'
+
+export async function GET() {
+  let dbPosts = null
+
+  if (
+    process.env.NEXT_PUBLIC_SUPABASE_URL &&
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+  ) {
+    const supabase = createClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY
+    )
+
+    const { data } = await supabase
+      .from(process.env.NEXT_PUBLIC_DB_VIEWS_TABLE)
+      .select()
+
+    dbPosts = data
+  }
+
+  const open = allPosts.filter((post) => post.status === 'open')
+
+  const latest = [...open]
+    .sort((a, b) => new Date(b.date) - new Date(a.date))
+    .slice(0, 10)
+
+  const popular = [...open]
+    .map((post) => ({
+      ...post,
+      view_count: dbPosts?.find((p) => p.slug === post.slug)?.view_count || 0,
+    }))
+    .sort((a, b) => b.view_count - a.view_count)
+    .slice(0, 10)
+
+  const line = (post) =>
+    `- [${post.title}](${siteMetadata.siteUrl}${post.slug})`
+
+  const markdown = `---
+title: ${siteMetadata.title}
+description: ${siteMetadata.description}
+url: ${siteMetadata.siteUrl}/
+---
+
+# ${siteMetadata.title}
+
+${siteMetadata.description}
+
+## Latest posts
+
+${latest.map(line).join('\n')}
+
+## Popular posts
+
+${popular.map(line).join('\n')}
+
+## Browse
+
+- [Full archive](${siteMetadata.siteUrl}/blog)
+- [Notes](${siteMetadata.siteUrl}/notes)
+- [Design articles](${siteMetadata.siteUrl}/category/design)
+- [Code articles](${siteMetadata.siteUrl}/category/code)
+- [Typography articles](${siteMetadata.siteUrl}/category/typography)
+- [About](${siteMetadata.siteUrl}/about)
+
+## Feeds
+
+- [RSS feed](${siteMetadata.siteUrl}/feed.xml)
+- [llms.txt](${siteMetadata.siteUrl}/llms.txt)
+`
+
+  return new Response(markdown, {
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+    },
+  })
+}

--- a/proxy.js
+++ b/proxy.js
@@ -13,6 +13,7 @@ const LINK_HEADER = [
 const MARKDOWN_ACCEPT = /(^|,\s*)text\/markdown(\s*;|\s*,|\s*$)/i
 
 const MARKDOWN_ROUTES = [
+  { pattern: /^\/$/, target: () => '/api/content/home' },
   { pattern: /^\/blog\/(.+)$/, target: (slug) => `/api/content/${slug}` },
   {
     pattern: /^\/notes\/(.+)$/,


### PR DESCRIPTION
## Summary

PR #301 added RFC 8288 Link headers, the API catalog, and the agent skills index, and wired `Accept: text/markdown` negotiation for `/blog/{slug}`, `/notes/{slug}`, etc. It missed the homepage — `/` had no markdown mapping, so the Markdown for Agents audit still reports the site as unsupported.

- Add `app/api/content/home/route.js` returning a markdown overview of the homepage (frontmatter + latest posts + popular posts + browse/feeds links).
- Map `/` &rarr; `/api/content/home` in `proxy.js` so `GET /` with `Accept: text/markdown` returns `Content-Type: text/markdown` while HTML stays the browser default.

## Test plan

Verified locally against `pnpm dev`:

- [ ] `curl -i -H "Accept: text/markdown" http://localhost:3000/` returns `content-type: text/markdown; charset=utf-8` with YAML frontmatter.
- [ ] `curl -I http://localhost:3000/` still returns `content-type: text/html` and includes the Link headers.
- [ ] `curl -i -H "Accept: text/markdown" http://localhost:3000/blog/bento-layout-css-grid` still returns markdown (unchanged behaviour).
- [ ] Re-run the [isitagentready.com](https://isitagentready.com) audit after deploy and confirm the *Markdown for Agents* check flips green.

https://claude.ai/code/session_01SLfyZ6Wpxbr7zjrgywbhnf

---
_Generated by [Claude Code](https://claude.ai/code/session_01SLfyZ6Wpxbr7zjrgywbhnf)_