### PR TITLE
Darken dark mode canvas with new fern-1400 shade

### DIFF
--- a/css/primitives.css
+++ b/css/primitives.css
@@ -233,6 +233,7 @@
   --color-fern-1100: oklch(26.8% 0.059 173.5);
   --color-fern-1200: oklch(22.9% 0.039087 171.7);
   --color-fern-1300: oklch(20.2% 0.035089 171.8);
+  --color-fern-1400: oklch(16% 0.028 171.8);
 
   --color-cornflour-0: rgb(235 242 250);
   --color-cornflour-100: rgb(203 223 248);

--- a/css/theme.css
+++ b/css/theme.css
@@ -92,7 +92,7 @@
     var(--color-canvas-dark)
   );
   --color-canvas-light: var(--color-neutral-01-150);
-  --color-canvas-dark: var(--color-fern-1300);
+  --color-canvas-dark: var(--color-fern-1400);
 
   --color-surface: light-dark(
     rgb(255 255 255),


### PR DESCRIPTION
Adds fern-1400 at oklch(16% 0.028 171.8) and points --color-canvas-dark
at it so lifted surfaces (fern-1100/1200 menus, code blocks, header)
read as more elevated against the darker page background.

https://claude.ai/code/session_01KEapEmb51rQpXRF6hdJdNp