### PR TITLE
Address website audit: SEO metadata, accessibility, import casing

### DIFF
--- a/app/(blog)/blog/page/[page]/page.js
+++ b/app/(blog)/blog/page/[page]/page.js
@@ -16,6 +16,21 @@ export const dynamic = 'force-dynamic'
 export const revalidate = false
 const POSTS_PER_PAGE = 12
 
+export async function generateMetadata(props) {
+  const params = await props.params
+  const pageNumber = parseInt(params.page) || 1
+
+  return {
+    title: pageNumber > 1 ? `Blog • Page ${pageNumber}` : 'Blog',
+    description:
+      'Tips and tutorials about the design and build of web interfaces',
+    alternates: {
+      canonical: '/blog',
+    },
+    robots: pageNumber > 1 ? { index: false, follow: true } : undefined,
+  }
+}
+
 const getData = cache(async () => {
   const postsByDate = sortPosts(allPosts).filter(
     (post) => post.status === 'open'

--- a/app/(blog)/category/[slug]/page/[page]/page.js
+++ b/app/(blog)/category/[slug]/page/[page]/page.js
@@ -57,10 +57,19 @@ export async function generateMetadata(props) {
     return
   }
 
+  const pageNumber = parseInt(params.page) || 1
+
   return {
     template: '%s • iamsteve',
-    title: category.title,
+    title:
+      pageNumber > 1
+        ? `${category.title} • Page ${pageNumber}`
+        : category.title,
     description: category.description,
+    alternates: {
+      canonical: `/category/${params.slug}`,
+    },
+    robots: pageNumber > 1 ? { index: false, follow: true } : undefined,
   }
 }
 

--- a/app/(blog)/notes/[...slug]/page.js
+++ b/app/(blog)/notes/[...slug]/page.js
@@ -58,11 +58,20 @@ export async function generateMetadata(props) {
       publishedTime: note.date,
       authors: [siteMetadata.author],
       url: `${note.slug}`,
+      images: [
+        {
+          url: siteMetadata.socialBanner,
+          width: 1200,
+          height: 600,
+          alt: note.title,
+        },
+      ],
     },
     twitter: {
-      card: 'summary',
+      card: 'summary_large_image',
       title: note.title,
       description: note.summary ?? '',
+      images: [siteMetadata.socialBanner],
     },
   }
 }
@@ -79,19 +88,54 @@ export default async function NotePage(props) {
 
   const jsonLD = {
     '@context': 'https://schema.org',
-    '@type': 'BlogPosting',
-    '@id': `${siteMetadata.siteUrl}${note.slug}#article`,
-    author: {
-      '@type': 'Person',
-      name: siteMetadata.author,
-    },
-    headline: note.title,
-    datePublished: note.date,
-    description: note.summary,
-    mainEntityOfPage: {
-      '@type': 'WebPage',
-      '@id': `${siteMetadata.siteUrl}${note.slug}`,
-    },
+    '@graph': [
+      {
+        '@type': 'BlogPosting',
+        '@id': `${siteMetadata.siteUrl}${note.slug}#article`,
+        isPartOf: {
+          '@id': `${siteMetadata.siteUrl}/#website`,
+        },
+        author: {
+          '@type': 'Person',
+          name: siteMetadata.author,
+          '@id': `${siteMetadata.siteUrl}/#person`,
+        },
+        headline: note.title,
+        datePublished: note.date,
+        description: note.summary,
+        mainEntityOfPage: {
+          '@type': 'WebPage',
+          '@id': `${siteMetadata.siteUrl}${note.slug}`,
+        },
+        publisher: {
+          '@id': `${siteMetadata.siteUrl}/#organization`,
+        },
+      },
+      {
+        '@type': 'BreadcrumbList',
+        '@id': `${siteMetadata.siteUrl}${note.slug}#breadcrumb`,
+        itemListElement: [
+          {
+            '@type': 'ListItem',
+            position: 1,
+            name: 'iamsteve.me',
+            item: `${siteMetadata.siteUrl}`,
+          },
+          {
+            '@type': 'ListItem',
+            position: 2,
+            name: 'Notes',
+            item: `${siteMetadata.siteUrl}/notes`,
+          },
+          {
+            '@type': 'ListItem',
+            position: 3,
+            name: note.title,
+            item: `${siteMetadata.siteUrl}${note.slug}`,
+          },
+        ],
+      },
+    ],
   }
 
   return (

--- a/app/(blog)/notes/page.js
+++ b/app/(blog)/notes/page.js
@@ -16,11 +16,37 @@ import Badge from '@/components/badge'
 import Link from '@/components/link'
 import { NoteFeedContent } from '@/components/note-feed-content'
 import CopyLink from '@/components/button/copy-link'
+import siteMetadata from '@/content/metadata'
 
 export const metadata = {
   title: 'Notes',
   description:
     'Quick, short and simple posts, a feed for everything outside design and code',
+  alternates: {
+    canonical: '/notes',
+  },
+  openGraph: {
+    title: 'Notes • iamsteve',
+    description:
+      'Quick, short and simple posts, a feed for everything outside design and code',
+    url: '/notes',
+    type: 'website',
+    images: [
+      {
+        url: siteMetadata.socialBanner,
+        width: 1200,
+        height: 600,
+        alt: 'iamsteve — notes',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'Notes • iamsteve',
+    description:
+      'Quick, short and simple posts, a feed for everything outside design and code',
+    images: [siteMetadata.socialBanner],
+  },
 }
 
 export const dynamic = 'force-static'

--- a/app/(page)/components/layout.js
+++ b/app/(page)/components/layout.js
@@ -1,0 +1,16 @@
+export const metadata = {
+  title: 'Components',
+  description:
+    'A reference page for MDX components used across the iamsteve.me blog.',
+  alternates: {
+    canonical: '/components',
+  },
+  robots: {
+    index: false,
+    follow: true,
+  },
+}
+
+export default function ComponentsLayout({ children }) {
+  return children
+}

--- a/app/(page)/newsletter/page.js
+++ b/app/(page)/newsletter/page.js
@@ -8,6 +8,22 @@ import ErrorBoundary from '@/components/error-boundary'
 import { allPosts } from 'content-collections'
 export const revalidate = 2592000
 
+export const metadata = {
+  title: 'Newsletter',
+  description:
+    'Get notified when new articles about design, typography and CSS are published. Monthly at most. Unsubscribe anytime.',
+  alternates: {
+    canonical: '/newsletter',
+  },
+  openGraph: {
+    title: 'Newsletter • iamsteve',
+    description:
+      'Get notified when new articles about design, typography and CSS are published. Monthly at most. Unsubscribe anytime.',
+    url: '/newsletter',
+    type: 'website',
+  },
+}
+
 export default async function NewsletterPage({ data, Post }) {
   const includedPosts = [165, 164, 72, 157, 160]
   const posts = allPosts

--- a/app/(page)/thanks/page.js
+++ b/app/(page)/thanks/page.js
@@ -10,6 +10,18 @@ import Campaigns from '../newsletter/campaigns'
 import { allPosts } from 'content-collections'
 export const revalidate = 2592000
 
+export const metadata = {
+  title: 'Thanks',
+  description: 'Your newsletter subscription has been confirmed.',
+  alternates: {
+    canonical: '/thanks',
+  },
+  robots: {
+    index: false,
+    follow: true,
+  },
+}
+
 export default async function NewsletterPage({ data, Post }) {
   const includedPosts = [160, 161, 157, 164, 165, 72]
   const posts = allPosts

--- a/app/layout.js
+++ b/app/layout.js
@@ -21,7 +21,7 @@ export const metadata = {
   description:
     'A blog by Steve McKinney about the design and build of websites. Bridging the gap between your design tool and code, with a focus on typography, CSS and visual craft.',
   alternates: {
-    canonical: './',
+    canonical: siteMetadata.siteUrl,
     types: {
       'application/rss+xml': `${siteMetadata.siteUrl}/feed.xml`,
     },
@@ -41,7 +41,7 @@ export const metadata = {
     title: 'iamsteve • design & code blog',
     description:
       'A blog by Steve McKinney about the design and build of websites. Bridging the gap between your design tool and code, with a focus on typography, CSS and visual craft.',
-    url: './',
+    url: siteMetadata.siteUrl,
     siteName: 'iamsteve',
     locale: 'en_GB',
     type: 'website',

--- a/components/Search.js
+++ b/components/Search.js
@@ -12,7 +12,7 @@ import CardLayout from '@/layouts/CardLayout'
 import Card from '@/components/card'
 import Icon from '@/components/icon'
 import Link from '@/components/link'
-import Pagination from '@/components/Pagination'
+import Pagination from '@/components/pagination'
 import Tag from '@/components/Tag'
 
 export default function Search({

--- a/components/Tabbar.js
+++ b/components/Tabbar.js
@@ -1,4 +1,4 @@
-import Link from './Link'
+import Link from './link'
 import { useRouter } from 'next/router'
 import headerNavLinks from '@/data/headerNavLinks'
 import Icon from '@/components/icon/index.js'

--- a/components/contact-form.js
+++ b/components/contact-form.js
@@ -39,6 +39,7 @@ const Toast = ({ open, onOpenChange, title, description }) => {
         <p className="font-medium m-0">{title}</p>
         <p className="m-0">{description}</p>
         <button
+          type="button"
           onClick={() => onOpenChange(false)}
           className="w-6 h-6 flex items-center justify-center absolute top-0 right-0"
           aria-label="Close"

--- a/components/figure-modal.js
+++ b/components/figure-modal.js
@@ -6,6 +6,7 @@ import {
   animate,
   useMotionValue,
   useMotionValueEvent,
+  useReducedMotion,
 } from 'motion/react'
 import { Modal } from '@/components/modal'
 import Icon from '@/components/icon'
@@ -18,6 +19,7 @@ const DISMISS_X_DAMPING = 0.3
 const SPRING_SNAP = { type: 'spring', stiffness: 400, damping: 40 }
 const SPRING_RESET = { type: 'spring', stiffness: 300, damping: 35 }
 const SPRING_DISMISS = { type: 'spring', stiffness: 250, damping: 30 }
+const INSTANT = { duration: 0 }
 const DOUBLE_TAP_MS = 300
 const DOUBLE_TAP_PX = 30
 const DISMISS_VY = 500
@@ -67,6 +69,11 @@ function LightboxContent({ src, alt, close }) {
   const yValue = useMotionValue(0)
   const opacityVal = useMotionValue(1)
 
+  const prefersReducedMotion = useReducedMotion()
+  const snapTransition = prefersReducedMotion ? INSTANT : SPRING_SNAP
+  const resetTransition = prefersReducedMotion ? INSTANT : SPRING_RESET
+  const dismissTransition = prefersReducedMotion ? INSTANT : SPRING_DISMISS
+
   const snapToBounds = useCallback(() => {
     const s = scaleValue.get()
     const { minX, maxX, minY, maxY } = getBoundsAtScale(
@@ -77,28 +84,28 @@ function LightboxContent({ src, alt, close }) {
     const cy = yValue.get()
     const clampedX = clamp(cx, minX, maxX)
     const clampedY = clamp(cy, minY, maxY)
-    if (cx !== clampedX) animate(xValue, clampedX, SPRING_SNAP)
-    if (cy !== clampedY) animate(yValue, clampedY, SPRING_SNAP)
-  }, [scaleValue, xValue, yValue])
+    if (cx !== clampedX) animate(xValue, clampedX, snapTransition)
+    if (cy !== clampedY) animate(yValue, clampedY, snapTransition)
+  }, [scaleValue, xValue, yValue, snapTransition])
 
   const toggleZoom = useCallback(
     (clientX, clientY) => {
       const scale = scaleValue.get()
       if (scale > 1) {
-        animate(scaleValue, 1, SPRING_RESET)
-        animate(xValue, 0, SPRING_RESET)
-        animate(yValue, 0, SPRING_RESET)
+        animate(scaleValue, 1, resetTransition)
+        animate(xValue, 0, resetTransition)
+        animate(yValue, 0, resetTransition)
       } else {
         const viewportCentreX = window.innerWidth / 2
         const viewportCentreY = window.innerHeight / 2
         const newX = -(clientX - viewportCentreX) * (ZOOM_TARGET - 1)
         const newY = -(clientY - viewportCentreY) * (ZOOM_TARGET - 1)
-        animate(scaleValue, ZOOM_TARGET, SPRING_RESET)
-        animate(xValue, newX, SPRING_RESET)
-        animate(yValue, newY, SPRING_RESET)
+        animate(scaleValue, ZOOM_TARGET, resetTransition)
+        animate(xValue, newX, resetTransition)
+        animate(yValue, newY, resetTransition)
       }
     },
-    [scaleValue, xValue, yValue]
+    [scaleValue, xValue, yValue, resetTransition]
   )
 
   // Update cursor via DOM to avoid re-renders
@@ -153,14 +160,14 @@ function LightboxContent({ src, alt, close }) {
 
       // Snap when zooming settles at min scale
       if (newScale <= MIN_SCALE) {
-        animate(xValue, 0, SPRING_RESET)
-        animate(yValue, 0, SPRING_RESET)
+        animate(xValue, 0, resetTransition)
+        animate(yValue, 0, resetTransition)
       }
     }
 
     el.addEventListener('wheel', onWheel, { passive: false })
     return () => el.removeEventListener('wheel', onWheel)
-  }, [scaleValue, xValue, yValue])
+  }, [scaleValue, xValue, yValue, resetTransition])
 
   // Pinch-to-zoom via raw pointer events
   useEffect(() => {
@@ -397,29 +404,43 @@ function LightboxContent({ src, alt, close }) {
         const vy = Math.abs(info.velocity.y)
         const dy = Math.abs(yValue.get())
         if (vy > DISMISS_VY || dy > DISMISS_DY) {
-          const direction = yValue.get() >= 0 ? 1 : -1
-          animate(yValue, direction * (window.innerHeight + 300), {
-            ...SPRING_DISMISS,
-            onComplete: close,
-          })
-          animate(opacityVal, 0, { duration: 0.25 })
+          if (prefersReducedMotion) {
+            close()
+          } else {
+            const direction = yValue.get() >= 0 ? 1 : -1
+            animate(yValue, direction * (window.innerHeight + 300), {
+              ...SPRING_DISMISS,
+              onComplete: close,
+            })
+            animate(opacityVal, 0, { duration: 0.25 })
+          }
         } else {
-          animate(xValue, 0, SPRING_RESET)
-          animate(yValue, 0, SPRING_RESET)
+          animate(xValue, 0, resetTransition)
+          animate(yValue, 0, resetTransition)
         }
       } else {
         const hasVelocity =
           Math.abs(info.velocity.x) > MOMENTUM_MIN_VELOCITY ||
           Math.abs(info.velocity.y) > MOMENTUM_MIN_VELOCITY
 
-        if (hasVelocity) {
+        if (hasVelocity && !prefersReducedMotion) {
           applyMomentum(info.velocity.x, info.velocity.y)
         } else {
           snapToBounds()
         }
       }
     },
-    [scaleValue, xValue, yValue, opacityVal, close, snapToBounds, applyMomentum]
+    [
+      scaleValue,
+      xValue,
+      yValue,
+      opacityVal,
+      close,
+      snapToBounds,
+      applyMomentum,
+      prefersReducedMotion,
+      resetTransition,
+    ]
   )
 
   return (

--- a/components/footer.js
+++ b/components/footer.js
@@ -1,4 +1,4 @@
-import Link from './Link'
+import Link from './link'
 import siteMetadata from '@/content/metadata'
 import SocialIcon from '@/components/social-icons'
 

--- a/components/header.js
+++ b/components/header.js
@@ -22,6 +22,12 @@ import {
 
 import styles from './header.module.css'
 
+function isActiveLink(pathname, href) {
+  if (!href) return false
+  if (href === '/') return pathname === '/'
+  return pathname === href || pathname.startsWith(`${href}/`)
+}
+
 function AccessibilityLinks({ isArticlePage }) {
   return (
     <ul
@@ -181,10 +187,12 @@ function Desktop({ pathname }) {
             )
           }
 
+          const isActive = isActiveLink(pathname, link.href)
           return (
             <li key={link.href}>
               <Link
                 href={link.href}
+                aria-current={isActive ? 'page' : undefined}
                 className={cn(
                   'flex items-center gap-1 text-base font-ui lowercase leading-none relative',
                   'lg:gap-2 lg:text-xl/none lg:py-1 xl:py-0.5',
@@ -235,11 +243,12 @@ function Tabbar({ pathname }) {
     >
       <ul className="flex justify-between max-lg:gap-6">
         {tabbar.map((link) => {
-          const isActive = pathname === link.href
+          const isActive = isActiveLink(pathname, link.href)
           return (
             <li key={link.href}>
               <Link
                 href={link.href}
+                aria-current={isActive ? 'page' : undefined}
                 className={cn(
                   'flex items-center gap-1 text-base font-ui lowercase leading-none relative',
                   'max-lg:text-[12px] max-lg:font-sans max-lg:font-medium max-lg:flex-col max-lg:flex-1 max-lg:justify-center max-lg:py-3',

--- a/components/newsletter-form.js
+++ b/components/newsletter-form.js
@@ -106,6 +106,7 @@ const NewsletterForm = ({
       <div className={className}>
         {subscribed && (
           <div
+            role="status"
             className={cn(
               'bg-grass-50/40',
               'rounded-sm',
@@ -122,6 +123,7 @@ const NewsletterForm = ({
         )}
         {error && (
           <div
+            role="alert"
             className={cn(
               'bg-rio-50/40',
               'rounded-sm',
@@ -221,9 +223,17 @@ const NewsletterForm = ({
                 required
                 disabled={subscribed}
                 onChange={() => setEmailError('')}
+                aria-invalid={emailError ? 'true' : undefined}
+                aria-describedby={
+                  emailError ? `input-email-${unique}-error` : undefined
+                }
               />
               {emailError && (
-                <p className={cn('text-red-500', 'text-sm', 'mt-1')}>
+                <p
+                  id={`input-email-${unique}-error`}
+                  role="alert"
+                  className={cn('text-red-500', 'text-sm', 'mt-1')}
+                >
                   {emailError}
                 </p>
               )}


### PR DESCRIPTION
Fixes from the website assessment:

- Lowercase mismatched imports (./Link, @/components/Pagination) so they
  resolve on case-sensitive filesystems
- Make root canonical and OG url absolute via siteMetadata.siteUrl
- Add generateMetadata with canonicals to /blog/page/[page],
  /category/[slug]/page/[page], /newsletter, /components, /thanks; mark
  pagination >1 noindex to consolidate ranking signals
- Add OG image (socialBanner) and summary_large_image Twitter card to
  notes index and detail pages; add BreadcrumbList JSON-LD to notes detail
- Respect prefers-reduced-motion in figure-modal (instant transitions,
  skip dismiss spring and momentum)
- Wire aria-describedby/aria-invalid on newsletter email error, role
  status/alert on form banners, type=button on toast close
- Add aria-current=page to desktop and tabbar nav links