### PR TITLE
Convert /portfolio, /mo, /2 to 410 and fix garbled blog entry URL

### DIFF
--- a/content/blog/0086-redirecting-an-old-domain-to-a-new-domain-with-nginx.md
+++ b/content/blog/0086-redirecting-an-old-domain-to-a-new-domain-with-nginx.md
@@ -81,7 +81,7 @@ server {
 }
 ```
 
-The important things to note here: we're hardcoding `https://` rather than using `$scheme` so the redirect always lands on HTTPS regardless of how the request came in. And `$request_uri` preserves anything after the domain, so `/blog/some-post` on the old domain redirects to `/blog/some-post` on the new one. Your visitors and any existing links will end up in the right place.
+The important things to note here: we're hardcoding `https://` rather than using `$scheme` so the redirect always lands on HTTPS regardless of how the request came in. And `$request_uri` preserves anything after the domain, so a path like `/blog/<slug>` on the old domain ends up at the same path on the new one. Your visitors and any existing links will end up in the right place.
 
 Update any other instances of `server_name` throughout your config file that you may have.
 

--- a/content/blog/0173-about-version-7/index.md
+++ b/content/blog/0173-about-version-7/index.md
@@ -66,7 +66,7 @@ Thankfully one was far easier than the others.
 
 One of the things I felt ~~could~~ would be a problem was the current URL structure surrounding blog posts. And I didn’t want to have that as a problem on top of moving to Next.js and a new hosting platform.
 
-The structure was `/blog/entry/[slug]` and was moving to `/blog/[slug]`.
+The structure was `/blog/entry/<slug>` and was moving to `/blog/<slug>`.
 
 I was aware this would break links from other websites, for which I setup redirects. And knew by the time I’d finally finish redeveloping the website on Next all the issues will have been ironed out.
 

--- a/next.config.js
+++ b/next.config.js
@@ -195,6 +195,11 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source: '/blog/entry/:slug(horizontal-scrolling-responsive-menu.*)',
+        destination: '/blog/horizontal-scrolling-responsive-menu',
+        permanent: true,
+      },
+      {
         source: '/blog/about_version_six',
         destination: '/blog/about-version-six',
         permanent: true,
@@ -311,11 +316,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/portfolio',
-        destination: '/about',
-        permanent: true,
-      },
-      {
         source: '/blog/\\{site_url\\}',
         destination: '/blog',
         permanent: true,
@@ -326,18 +326,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/mo',
-        destination: '/',
-        permanent: true,
-      },
-      {
         source: '/blog/entry/sass_hints_tips',
         destination: '/blog/sass-hints-and-tips',
-        permanent: true,
-      },
-      {
-        source: '/2',
-        destination: '/',
         permanent: true,
       },
       {

--- a/proxy.js
+++ b/proxy.js
@@ -73,6 +73,7 @@ const GONE_PATHS = [
   '/blog/some-post',
   '/2',
   '/mo',
+  '/**',
 ]
 
 const GONE_PREFIXES = ['/Users/']
@@ -129,6 +130,6 @@ export const config = {
      * - favicon.ico
      * - public assets (images, fonts, icons)
      */
-    '/((?!_next/static|_next/image|favicon.ico|images|fonts|icon).*)',
+    '/((?!_next/static|_next/image|favicon.ico|images|icon).*)',
   ],
 }


### PR DESCRIPTION
Drop redirects for paths that should signal gone, since the proxy
middleware runs first and 410s are clearer for Search Console. Also
remove fonts from the middleware matcher so /fonts/InterVariable.woff2
actually returns 410, and add a catch-all redirect for the
horizontal-scrolling-responsive-menu slug with HTML-entity garbage.