### PR TITLE
Restore keyword titles and fix curly-quote summary delimiters

### DIFF
--- a/content/blog/0058-svg-reusability-animation.md
+++ b/content/blog/0058-svg-reusability-animation.md
@@ -2,7 +2,7 @@
 title: 'SVG reusability & animation'
 date: '2015-01-27T08:00:00+00:00'
 lastmod: '2021-06-11T06:05:56+00:00'
-summary: ‘How to animate and reuse inline SVG with CSS. Using currentColor and groups you can change fills and animate paths, saving on page weight by avoiding multiple images.’
+summary: 'How to animate and reuse inline SVG with CSS. Using currentColor and groups you can change fills and animate paths, saving on page weight by avoiding multiple images.'
 metadesc: 'How to animate and change fill colours on inline SVG. Using currentcolor and groups we can animate and manipulate SVG unlike any other image type.'
 theme: '#ffede5'
 tags: ['Code']

--- a/content/blog/0059-overcoming-a-couple-of-issues-with-svg-filter-effects.md
+++ b/content/blog/0059-overcoming-a-couple-of-issues-with-svg-filter-effects.md
@@ -2,7 +2,7 @@
 title: 'Overcoming a couple of issues with SVG filter effects'
 date: '2015-02-03T08:00:00+00:00'
 lastmod: '2016-08-28T12:54:02+00:00'
-summary: ‘SVG filter effects are useful for illustration details on the web. This post covers two problems encountered using Gaussian blur — lower saturation in Safari and filter clipping.’
+summary: 'SVG filter effects are useful for illustration details on the web. This post covers two problems encountered using Gaussian blur — lower saturation in Safari and filter clipping.'
 metadesc: 'SVG filters are really useful for infinitely scalable effects but they come with some issues, such as appearing with lower saturation in Safari and filter clipping at certain sizes.'
 theme: '#fffbf2'
 tags: ['Code']

--- a/content/blog/0066-adobe-generator-syntax-cheatsheet.md
+++ b/content/blog/0066-adobe-generator-syntax-cheatsheet.md
@@ -2,7 +2,7 @@
 title: 'Adobe generator syntax ‘cheatsheet’'
 date: '2015-03-17T08:00:00+00:00'
 lastmod: '2018-06-01T08:49:16+00:00'
-summary: ‘A clear reference for Adobe Generator layer naming syntax, with examples for common use cases — the cheatsheet the Adobe docs never quite provided.’
+summary: 'A clear reference for Adobe Generator layer naming syntax, with examples for common use cases — the cheatsheet the Adobe docs never quite provided.'
 metadesc: 'A cheatsheet for Adobe’s generator syntax, with examples for common use cases.'
 theme: '#e1f7ee'
 tags: ['Design']

--- a/content/blog/0071-using-cookies-to-serve-critical-css-for-first-time-visits.md
+++ b/content/blog/0071-using-cookies-to-serve-critical-css-for-first-time-visits.md
@@ -2,7 +2,7 @@
 title: 'Using cookies to serve critical CSS for first time visits'
 date: '2015-04-21T06:45:00+00:00'
 lastmod: '2016-08-28T11:00:46+00:00'
-summary: ‘How to use cookies with critical path CSS so returning visitors load the full stylesheet instead. A follow-up to the critical CSS post, covering the caching side.’
+summary: 'How to use cookies with critical path CSS so returning visitors load the full stylesheet instead. A follow-up to the critical CSS post, covering the caching side.'
 metadesc: 'How to use cookies to cache your critical CSS. A simple approach involving making your CSS asynchronous, applying a cookie and checking for it.'
 theme: '#ffede5'
 tags: ['Code']

--- a/content/blog/0073-flexbox-quick-wins.md
+++ b/content/blog/0073-flexbox-quick-wins.md
@@ -2,7 +2,7 @@
 title: 'Flexbox quick wins'
 date: '2015-05-05T06:00:00+00:00'
 lastmod: '2016-08-28T11:00:20+00:00'
-summary: ‘A few flexbox techniques you can use today without worrying about older browser knock-on effects. Handy when you don’t have time for a full flexbox layout.’
+summary: 'A few flexbox techniques you can use today without worrying about older browser knock-on effects. Handy when you don’t have time for a full flexbox layout.'
 metadesc: 'Flexbox isn‘t quite ready to have layouts built dedicated with it. There are some uses with flexbox we can apply without worry of what will impact other browsers.'
 theme: '#e9f5f5'
 tags: ['Code']

--- a/content/blog/0087-a-guide-to-vertical-rhythm.md
+++ b/content/blog/0087-a-guide-to-vertical-rhythm.md
@@ -2,7 +2,7 @@
 title: 'A guide to vertical rhythm'
 date: '2015-08-11T06:41:00+00:00'
 lastmod: '2018-10-15T11:09:25+00:00'
-summary: ‘Vertical rhythm creates visual harmony between text and other elements on a page. This guide focuses on the why rather than the how, to build a solid understanding.’
+summary: 'Vertical rhythm creates visual harmony between text and other elements on a page. This guide focuses on the why rather than the how, to build a solid understanding.'
 metadesc: "If you've ever struggled with how vertical rhythm is achieved, I will guide you through how you choose a baseline, sizing and images."
 theme: '#fffbee'
 tags: ['Design']

--- a/content/blog/0089-accuracy-in-wireframes.md
+++ b/content/blog/0089-accuracy-in-wireframes.md
@@ -2,7 +2,7 @@
 title: 'Accuracy in wireframes'
 date: '2015-08-25T06:17:00+00:00'
 lastmod: '2016-08-28T10:54:41+00:00'
-summary: ‘Why wireframes should strip all visual style and focus purely on layout. Accurate wireframes make for a stronger foundation before adding visual design.’
+summary: 'Why wireframes should strip all visual style and focus purely on layout. Accurate wireframes make for a stronger foundation before adding visual design.'
 metadesc: 'My opinion on why wireframes should be completely accurate to the final design and how it can save you time and frustration.'
 theme: '#e9f5f5'
 tags: ['Design']

--- a/content/blog/0098-using-grunticon-to-inline-svg.md
+++ b/content/blog/0098-using-grunticon-to-inline-svg.md
@@ -2,7 +2,7 @@
 title: 'Using Grunticon to inline SVG'
 date: '2015-10-27T07:34:00+00:00'
 lastmod: '2016-08-28T10:49:57+00:00'
-summary: ‘Grunticon V2 added the ability to insert inline SVG, generating fallbacks for older browsers. Inline SVG is easily styled with CSS, all done via a Grunt task.’
+summary: 'Grunticon V2 added the ability to insert inline SVG, generating fallbacks for older browsers. Inline SVG is easily styled with CSS, all done via a Grunt task.'
 metadesc: 'Grunticon updated to V2 a while ago now and what came with it was the ability to insert inline SVG. This post covers how to use it effectively.'
 theme: '#e1f7ee'
 tags: ['Code']

--- a/content/blog/0100-tips-for-sketching-websites.md
+++ b/content/blog/0100-tips-for-sketching-websites.md
@@ -2,7 +2,7 @@
 title: 'Tips for sketching websites'
 date: '2015-11-10T07:29:00+00:00'
 lastmod: '2016-08-28T10:49:36+00:00'
-summary: ‘Sketching before wireframing is easy to skip, but you’re missing out if you do. This post walks through a process for sketching websites, even if you don’t think you can draw.’
+summary: 'Sketching before wireframing is easy to skip, but you’re missing out if you do. This post walks through a process for sketching websites, even if you don’t think you can draw.'
 metadesc: "I believe sketching should always be part of your process. It's the quickest method to iterate and ingrain ideas in our minds."
 theme: '#fffbf2'
 tags: ['Design']

--- a/content/blog/0105-colour-series-picking-your-palette.md
+++ b/content/blog/0105-colour-series-picking-your-palette.md
@@ -2,7 +2,7 @@
 title: 'Colour series: picking your palette'
 date: '2015-12-15T07:28:00+00:00'
 lastmod: '2018-03-07T13:17:26+00:00'
-summary: ‘Part one of the colour series. Colour theory is only a starting point — this post walks through what to actually consider when picking a 5-colour palette for a project.’
+summary: 'Part one of the colour series. Colour theory is only a starting point — this post walks through what to actually consider when picking a 5-colour palette for a project.'
 metadesc: 'How to choose an effective colour for your website project. From colours that represent your project to ones that help readability.'
 theme: '#f9f3f1'
 tags: ['Design']

--- a/content/blog/0109-horizontal-scrolling-toggle.md
+++ b/content/blog/0109-horizontal-scrolling-toggle.md
@@ -2,7 +2,7 @@
 title: 'Browse content efficiently with toggling horizontal scrolling'
 date: '2016-01-12T07:30:00+00:00'
 lastmod: '2021-06-17T06:24:00+00:00'
-summary: ‘A Finder-inspired pattern for toggling between horizontal and vertical scrolling layouts. Built with flexbox, making it easy to switch between compact and expanded views.’
+summary: 'A Finder-inspired pattern for toggling between horizontal and vertical scrolling layouts. Built with flexbox, making it easy to switch between compact and expanded views.'
 metadesc: 'Allow for the best of both worlds with horizontal scrolling and toggle to vertical layout. Using flexbox this makes layouts easy to adjust.'
 theme: '#e9f5f5'
 tags: ['Code']

--- a/content/blog/0112-how-to-flexible-squares-with-css.md
+++ b/content/blog/0112-how-to-flexible-squares-with-css.md
@@ -2,7 +2,7 @@
 title: 'How to: flexible squares with CSS'
 date: '2016-02-02T07:30:00+00:00'
 lastmod: '2018-01-28T20:21:51+00:00'
-summary: ‘How to maintain a perfect square in a responsive layout using CSS padding. A quick tip covering the technique and how to handle content within the square.’
+summary: 'How to maintain a perfect square in a responsive layout using CSS padding. A quick tip covering the technique and how to handle content within the square.'
 metadesc: "How do you maintain a perfect square shape with a responsive layout? It's a relatively simple solution using padding."
 theme: '#fffdf5'
 tags: ['Code', 'CSS']

--- a/content/blog/0120-hero-area-series-html-css-responsive.md
+++ b/content/blog/0120-hero-area-series-html-css-responsive.md
@@ -2,7 +2,7 @@
 title: 'Hero area series: HTML, CSS & responsive'
 date: '2016-04-05T06:30:00+00:00'
 lastmod: '2016-08-28T09:58:02+00:00'
-summary: ‘Coding the hero area using flexbox and making it responsive. A mostly mobile-first approach, applying CSS where it makes logical sense to avoid undoing it later.’
+summary: 'Coding the hero area using flexbox and making it responsive. A mostly mobile-first approach, applying CSS where it makes logical sense to avoid undoing it later.'
 metadesc: 'The second to last post in this series, coding the page. You’re going to build the page using flexbox and make it responsive.'
 theme: '#e9f5f5'
 tags: ['Design', 'Code']

--- a/content/blog/0129-why-you-should-use-tachyons-to-make-css-easier.md
+++ b/content/blog/0129-why-you-should-use-tachyons-to-make-css-easier.md
@@ -2,7 +2,7 @@
 title: 'Why you should use tachyons to make CSS easier'
 date: '2016-06-07T06:30:00+00:00'
 lastmod: '2016-08-28T09:17:19+00:00'
-summary: ‘The tachyons approach to CSS makes sense, particularly for spacing and font sizes. This post explains the benefits and how to adapt it to how you already write CSS.’
+summary: 'The tachyons approach to CSS makes sense, particularly for spacing and font sizes. This post explains the benefits and how to adapt it to how you already write CSS.'
 metadesc: 'Find out how tachyons can help speed up building a website, but most of all keep things expected and consistent.'
 theme: '#e1f7ee'
 tags: ['Code', 'CSS']

--- a/content/blog/0135-css-only-ios-style-toggle.md
+++ b/content/blog/0135-css-only-ios-style-toggle.md
@@ -2,7 +2,7 @@
 title: 'CSS only iOS style ‘toggle’'
 date: '2016-07-19T06:30:00+00:00'
 lastmod: '2016-08-28T09:14:48+00:00'
-summary: ‘A CSS-only iOS-style toggle using a hidden checkbox and the :checked pseudo class with the adjacent sibling selector. No JavaScript required.’
+summary: 'A CSS-only iOS-style toggle using a hidden checkbox and the :checked pseudo class with the adjacent sibling selector. No JavaScript required.'
 metadesc: 'No JavaScript required, iOS style toggle with CSS. Using the :checked pseudo class and adjacent sibling selector it makes it possible.'
 theme: '#e9f5f5'
 tags: ['Code']

--- a/content/blog/0136-designing-a-pricing-table-in-code.md
+++ b/content/blog/0136-designing-a-pricing-table-in-code.md
@@ -2,7 +2,7 @@
 title: 'Designing a pricing table in code'
 date: '2016-07-26T06:37:00+00:00'
 lastmod: '2016-08-28T09:14:08+00:00'
-summary: ‘Coding up the pricing table designed in Illustrator. Flexbox handles the layout, keeping focus on matching the design and adding interactive button states.’
+summary: 'Coding up the pricing table designed in Illustrator. Flexbox handles the layout, keeping focus on matching the design and adding interactive button states.'
 metadesc: 'Using flexbox to do the heavy lifting for the layout, the focus can be on matching the design and improving on it through being able to show the button state.'
 theme: '#e9f5f5'
 tags: ['Code']

--- a/content/blog/0140-illustrator-quick-tip-equally-space-objects.md
+++ b/content/blog/0140-illustrator-quick-tip-equally-space-objects.md
@@ -2,7 +2,7 @@
 title: 'How to evenly space objects in Illustrator'
 date: '2016-08-23T06:30:00+00:00'
 lastmod: '2018-09-13T18:56:32+00:00'
-summary: ‘How to distribute objects with equal spacing in Illustrator using align to key object. A quick tip that saves spacing things out one by one.’
+summary: 'How to distribute objects with equal spacing in Illustrator using align to key object. A quick tip that saves spacing things out one by one.'
 metadesc: 'The quickest way to add equal spacing between objects in Illustrator. Use align to key object to distribute space with a precise pixel value.'
 theme: '#fefbed'
 tags: ['Design']

--- a/content/blog/0172-the-best-ink-trap-typefaces-for-websites.md
+++ b/content/blog/0172-the-best-ink-trap-typefaces-for-websites.md
@@ -1,7 +1,7 @@
 ---
-title: 'The best ink trap fonts for web design'
+title: 'The best ink trap typefaces for websites'
 date: '2021-07-28T10:28:00+00:00'
-lastmod: '2026-04-20T18:21:44+00:00'
+lastmod: '2026-06-12T20:45:00+00:00'
 summary: 'A look at type that features prominent cuts or tapering into the type and a variety of recommendations you can use in your designs.'
 metadesc: 'A curated collection of ink trap typefaces for websites, including free Google Fonts options and premium picks from foundries like OH no Type Co and Pangram Pangram.'
 theme: '#f9f3f1'

--- a/content/blog/0175-bento-layout-css-grid.md
+++ b/content/blog/0175-bento-layout-css-grid.md
@@ -1,7 +1,7 @@
 ---
-title: Build a bento grid layout with CSS
+title: Bento grid layout with CSS grid and container queries
 date: '2024-07-02T14:58:09.706Z'
-lastmod: '2026-04-20T17:48:51.000Z'
+lastmod: '2026-06-12T20:45:00.000Z'
 summary: Bento grids offer a unique layout challenge for CSS. With the use of Tailwind you can create a flexible layout with modern CSS grid and @container queries.
 metadesc: Build a responsive bento grid using CSS grid, container queries and Tailwind. Includes a Figma design file and complete code on GitHub.
 theme: '#fcf9f8'


### PR DESCRIPTION
- Revert bento article title to 'Bento grid layout with CSS grid and
  container queries' — the April retitle dropped the keywords the post
  ranks for, while the URL and meta description still target them
- Revert ink trap article title to 'The best ink trap typefaces for
  websites' to match the slug, meta description and image alt text
- Replace curly quotes used as YAML string delimiters in 17 post
  summaries — they were parsed as part of the value, so literal ‘…’
  appeared in the on-page lead and og:description