### PR TITLE
Prevent indexing of non-canonical hosts

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,17 +24,21 @@
       Cache-Control = "public, max-age=0, s-maxage=3600, stale-while-revalidate=60"
 
 # Development context (includes deploy previews and branch deploys)
+# X-Robots-Tag keeps non-production deploys out of Google's index while
+# leaving them crawlable, so the noindex is actually seen
 [context.deploy-preview]
   [[context.deploy-preview.headers]]
     for = "/*"
     [context.deploy-preview.headers.values]
       Cache-Control = "public, max-age=0, must-revalidate"
+      X-Robots-Tag = "noindex"
 
 [context.branch-deploy]
   [[context.branch-deploy.headers]]
     for = "/*"
     [context.branch-deploy.headers.values]
       Cache-Control = "public, max-age=0, must-revalidate"
+      X-Robots-Tag = "noindex"
 
 [[headers]]
   for = "/*"

--- a/proxy.js
+++ b/proxy.js
@@ -78,16 +78,27 @@ const GONE_PATHS = [
 
 const GONE_PREFIXES = ['/Users/']
 
+// Only the canonical host may be indexed. Archive subdomains, branch
+// deploys and previews stay crawlable so Google can see the noindex.
+const INDEXABLE_HOSTS = ['iamsteve.me', 'localhost']
+
 export function proxy(request) {
   const { pathname } = request.nextUrl
 
+  const respond = (response) => {
+    if (!INDEXABLE_HOSTS.includes(request.nextUrl.hostname)) {
+      response.headers.set('X-Robots-Tag', 'noindex')
+    }
+    return response
+  }
+
   if (GONE_PATHS.includes(pathname)) {
-    return new NextResponse(null, { status: 410 })
+    return respond(new NextResponse(null, { status: 410 }))
   }
 
   for (const prefix of GONE_PREFIXES) {
     if (pathname.startsWith(prefix)) {
-      return new NextResponse(null, { status: 410 })
+      return respond(new NextResponse(null, { status: 410 }))
     }
   }
 
@@ -102,7 +113,7 @@ export function proxy(request) {
   }
 
   if (stripped) {
-    return NextResponse.redirect(url, 301)
+    return respond(NextResponse.redirect(url, 301))
   }
 
   // Serve markdown when the agent asks for it via Accept header or .md suffix.
@@ -114,11 +125,11 @@ export function proxy(request) {
     if (target) {
       const rewriteUrl = request.nextUrl.clone()
       rewriteUrl.pathname = target
-      return withDiscoveryHeaders(NextResponse.rewrite(rewriteUrl))
+      return respond(withDiscoveryHeaders(NextResponse.rewrite(rewriteUrl)))
     }
   }
 
-  return withDiscoveryHeaders(NextResponse.next())
+  return respond(withDiscoveryHeaders(NextResponse.next()))
 }
 
 export const config = {


### PR DESCRIPTION
Serve X-Robots-Tag: noindex from the proxy for any host other than
iamsteve.me, and from Netlify deploy-preview and branch-deploy
contexts. Deploys stay crawlable so Google can see the noindex,
avoiding the 'Indexed, though blocked by robots.txt' trap.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CrzXqKPBbov2GBvXk7rYYm