### PR TITLE
Clear out dead collection links and correct their titles

### DIFF
--- a/content/collections/betterbydesign.md
+++ b/content/collections/betterbydesign.md
@@ -1,7 +1,7 @@
 ---
-title: Better by Design | Patrick Morgan | Substack
-url: "https://www.betterbydesign.cc/"
-date: "2025-03-13T21:05:39.299Z"
+title: Better by Design
+url: 'https://www.betterbydesign.cc/'
+date: '2025-03-13T21:05:39.299Z'
 collection:
   - Publication
 type: Collections

--- a/content/collections/bpando.md
+++ b/content/collections/bpando.md
@@ -1,7 +1,7 @@
 ---
-title: BP&O - Branding, Packaging and Opinion
-url: "https://bpando.org/"
-date: "2025-03-13T21:05:39.300Z"
+title: 'BP&O'
+url: 'https://bpando.org/'
+date: '2025-03-13T21:05:39.300Z'
 collection:
   - Publication
 type: Collections

--- a/content/collections/brandingwebsite.md
+++ b/content/collections/brandingwebsite.md
@@ -1,7 +1,7 @@
 ---
-title: Branding Website · Featuring the Best Branding Websites on the Internet
-url: "https://www.brandingwebsite.com/"
-date: "2025-03-13T21:05:39.294Z"
+title: Branding Website
+url: 'https://www.brandingwebsite.com/'
+date: '2025-03-13T21:05:39.294Z'
 collection:
   - Inspiration
 type: Collections

--- a/content/collections/brownjuice-study.md
+++ b/content/collections/brownjuice-study.md
@@ -1,7 +1,7 @@
 ---
-title: Design Externship
+title: UX smells
 url: https://brownjuice.co/study/?article=a3
-date: "2025-12-06T18:47:01.793Z"
+date: '2025-12-06T18:47:01.793Z'
 collection:
   - ux-design
 type: Collections

--- a/content/collections/c82-iconography.md
+++ b/content/collections/c82-iconography.md
@@ -1,7 +1,7 @@
 ---
-title: iconographic-encyclopaedia
-url: "https://www.c82.net/iconography/"
-date: "2025-03-13T21:05:39.296Z"
+title: Iconographic encyclopaedia
+url: 'https://www.c82.net/iconography/'
+date: '2025-03-13T21:05:39.296Z'
 collection:
   - misc
 type: Collections

--- a/content/collections/commercecream.md
+++ b/content/collections/commercecream.md
@@ -1,8 +1,0 @@
----
-title: Commerce Cream
-url: https://commercecream.com
-date: 2024-03-22
-collection:
-  - Inspiration
-type: Collections
----

--- a/content/collections/deadsimplesites.md
+++ b/content/collections/deadsimplesites.md
@@ -1,7 +1,7 @@
 ---
-title: Dead Simple Sites — Minimal Website Inspiration
-url: "https://deadsimplesites.com/"
-date: "2025-03-13T21:05:39.294Z"
+title: Dead Simple Sites
+url: 'https://deadsimplesites.com/'
+date: '2025-03-13T21:05:39.294Z'
 collection:
   - Inspiration
 type: Collections

--- a/content/collections/deck.md
+++ b/content/collections/deck.md
@@ -1,7 +1,7 @@
 ---
-title: Deck.Gallery® — Beautifully designed decks, curated
-url: "https://www.deck.gallery/"
-date: "2025-03-13T21:05:39.296Z"
+title: Deck.Gallery
+url: 'https://www.deck.gallery/'
+date: '2025-03-13T21:05:39.296Z'
 collection:
   - misc
 type: Collections

--- a/content/collections/drgurner-substack.md
+++ b/content/collections/drgurner-substack.md
@@ -1,7 +1,7 @@
 ---
-title: Ultra Successful | Dr. Julie Gurner | Substack
-url: "https://drgurner.substack.com/"
-date: "2025-03-13T21:05:39.299Z"
+title: Ultra Successful
+url: 'https://drgurner.substack.com/'
+date: '2025-03-13T21:05:39.299Z'
 collection:
   - Publication
 type: Collections

--- a/content/collections/kubie-blog-the-most-useful-articles-about-ux-content-and-design.md
+++ b/content/collections/kubie-blog-the-most-useful-articles-about-ux-content-and-design.md
@@ -1,7 +1,7 @@
 ---
-title: The Most Useful UX and Content Design Articles - kubie.co
-url: "https://kubie.co/blog/the-most-useful-articles-about-ux-content-and-design/"
-date: "2025-03-13T21:05:39.294Z"
+title: The most useful UX and content design articles
+url: 'https://kubie.co/blog/the-most-useful-articles-about-ux-content-and-design/'
+date: '2025-03-13T21:05:39.294Z'
 collection:
   - ux-design
 type: Collections

--- a/content/collections/logo-archive.md
+++ b/content/collections/logo-archive.md
@@ -1,7 +1,7 @@
 ---
-title: LogoArchive • Logo inspiration and historical archive
-url: "https://www.logo-archive.org/"
-date: "2025-03-13T21:05:39.296Z"
+title: LogoArchive
+url: 'https://www.logo-archive.org/'
+date: '2025-03-13T21:05:39.296Z'
 collection:
   - brand
 type: Collections

--- a/content/collections/medium-jinsoncjohny-color-formula-a-practical-framework-for-ui-designers-and-developers-working-with.md
+++ b/content/collections/medium-jinsoncjohny-color-formula-a-practical-framework-for-ui-designers-and-developers-working-with.md
@@ -1,7 +1,7 @@
 ---
-title: "Color Formula: A Practical Framework for UI Designers and Developers Working with Dynamic Colors"
+title: 'Color formula: a practical framework for UI designers and developers working with dynamic colors'
 url: https://medium.com/@jinsoncjohny/color-formula-a-practical-framework-for-ui-designers-and-developers-working-with-dynamic-colors-f1e6b2ef41d2
-date: "2025-12-06T18:47:01.794Z"
+date: '2025-12-06T18:47:01.794Z'
 collection:
   - Colour
 type: Collections

--- a/content/collections/news-arcade.md
+++ b/content/collections/news-arcade.md
@@ -1,7 +1,7 @@
 ---
-title: HI-FIVE | Arcade Labs | Substack
-url: "https://news.arcade.la/"
-date: "2025-03-13T21:05:39.298Z"
+title: HI-FIVE
+url: 'https://news.arcade.la/'
+date: '2025-03-13T21:05:39.298Z'
 collection:
   - Publication
 type: Collections

--- a/content/collections/snackablecopytips.md
+++ b/content/collections/snackablecopytips.md
@@ -1,8 +1,0 @@
----
-title: Snackable Copy Tips
-url: "https://www.snackablecopytips.com/"
-date: "2025-03-13T21:05:39.294Z"
-collection:
-  - Content
-type: Collections
----

--- a/content/collections/ta11y-learning.md
+++ b/content/collections/ta11y-learning.md
@@ -1,7 +1,7 @@
 ---
 title: Learn about Accessibility | ta11y
-url: "https://www.ta11y.org/learning"
-date: "2025-03-13T21:05:39.292Z"
+url: 'https://www.ta11y.org/en/learning'
+date: '2025-03-13T21:05:39.292Z'
 collection:
   - Accessibility
 type: Collections

--- a/content/collections/ta11y-learning.md
+++ b/content/collections/ta11y-learning.md
@@ -1,5 +1,5 @@
 ---
-title: Learn about Accessibility | ta11y
+title: Learn about accessibility
 url: 'https://www.ta11y.org/en/learning'
 date: '2025-03-13T21:05:39.292Z'
 collection:

--- a/content/collections/the-brandidentity.md
+++ b/content/collections/the-brandidentity.md
@@ -1,7 +1,7 @@
 ---
-title: The Brand Identity – Graphic Design’s Greatest
-url: "https://the-brandidentity.com/"
-date: "2025-03-13T21:05:39.298Z"
+title: The Brand Identity
+url: 'https://the-brandidentity.com/'
+date: '2025-03-13T21:05:39.298Z'
 collection:
   - Publication
 type: Collections

--- a/content/collections/visualjournal.md
+++ b/content/collections/visualjournal.md
@@ -1,7 +1,7 @@
 ---
-title: Visual Journal – Branding, Editorial and Graphic Design
-url: "https://visualjournal.it/"
-date: "2025-03-13T21:05:39.296Z"
+title: Visual Journal
+url: 'https://visualjournal.it/'
+date: '2025-03-13T21:05:39.296Z'
 collection:
   - brand
 type: Collections

--- a/link-check-ignore.json
+++ b/link-check-ignore.json
@@ -1,4 +1,7 @@
 {
   "_readme": "Links you have checked by hand and want the validator to leave alone. Add an entry to \"urls\" as \"the-url\": \"why it is fine\" — the reason is a note to yourself, the script only reads the key. Matching ignores protocol, www, trailing slash, fragments and tracking params, so https://www.example.com/ and https://example.com match the same entry. Example: \"https://example.com\": \"Cloudflare refuses CI runners, opened it manually 2026-08-01\".",
-  "urls": {}
+  "urls": {
+    "https://brownjuice.co/study/?article=a3": "UX smells. Refuses automated requests with a 403, opened by hand 2026-08-01 and fine",
+    "https://www.c82.net/iconography/": "Iconographic encyclopaedia. Refuses automated requests with a 403, opened by hand 2026-08-01 and fine"
+  }
 }

--- a/scripts/validate-collection-links.js
+++ b/scripts/validate-collection-links.js
@@ -281,6 +281,7 @@ function getFilesToCheck() {
     return output
       .split('\n')
       .filter((f) => f.startsWith(COLLECTIONS_DIR) && f.endsWith('.md'))
+      .filter((f) => fs.existsSync(f)) // a removed collection has nothing to check
   } catch {
     // Fallback: check all if git diff fails
     return fs


### PR DESCRIPTION
Follow-up to #325, working through what the weekly run in #318 actually found. The aim is that every link goes to a live site and carries a clear title. Everything here is verified rather than inferred, either by DNS, by CI, or by hand in a browser.

## Links removed

| Collection | Evidence |
|---|---|
| `snackablecopytips.md` | NXDOMAIN, on repeated lookups and for both apex and `www.` forms |
| `commercecream.md` | Resolves to `157.230.67.179` with nothing listening. `ECONNREFUSED` from CI and does not load from a residential connection either — a torn-down host with its DNS left in place |

While confirming the first, I swept DNS across every remaining collection host with retries, so a transient resolver failure could not be mistaken for a dead domain. **None fail to resolve**, so there are no other expired domains hiding in the list. DNS is worth leaning on because, unlike HTTP, it is not IP-reputation gated and can be trusted from anywhere.

## Links fixed

`ta11y.org` moved `/learning` behind a locale prefix without redirecting the old path. Updated to `/en/learning`, and the run on this PR confirmed it live from CI — a real 200, not an ambiguous result.

Worth noting it was listed in #318 as a definite 404, but that verdict came from a `HEAD` request alone, and #325 now retries `404` with a `GET` precisely because CDNs reject `HEAD` outright. It needed confirming by hand rather than trusting the report.

## Links acknowledged

`brownjuice.co/study` and `c82.net/iconography` both answer `403` to anything automated but load fine in a browser. Both are deep links, so the report surfaces them by design rather than collapsing them the way it does a blocked homepage, and they would otherwise be raised every week with nothing to act on. These are the first entries in `link-check-ignore.json`.

## Titles

Fifteen corrected. Two were outright wrong, found while checking the links above:

| Collection | Was | Now |
|---|---|---|
| `c82-iconography.md` | `iconographic-encyclopaedia` | Iconographic encyclopaedia |
| `brownjuice-study.md` | Design Externship | UX smells |

The first had a URL slug sitting in the title field rather than a title. The second named a different article to the one the link opens.

The other thirteen were raw page titles carrying the site name welded on with a separator, which is the browser tab's business rather than a title — "Better by Design | Patrick Morgan | Substack", "BP&O - Branding, Packaging and Opinion", "LogoArchive • Logo inspiration and historical archive". Site names keep their own capitalisation, being proper nouns; page and article titles take sentence case, so ta11y becomes "Learn about accessibility".

Left alone: Best Website Gallery, which reads like marketing but is simply what the site is called.

Titles do not affect routing — `slugAsParams` derives from the file path, not the title — so no collection URL changes.

## Checker fix: removals crashed the run

`git diff --name-only` lists deleted files alongside modified ones, so the validator tried to read a path that no longer existed:

```
Checking 1 collection files...
Error: ENOENT: no such file or directory, open 'content/collections/snackablecopytips.md'
```

Pre-existing, but removing a collection is exactly what triggers it, so it would have fired on this very branch. It fails softly — the `main().catch()` handler writes the fallback results file and the `-1` output from #325 correctly stops the issue steps firing — so the symptom is a PR comment saying the script errored rather than a red X. Easy to shrug off and leave broken.

Now filtered to files still on disk. Confirmed working by the run on this PR, which checked one file rather than two and did not crash.

## Still open

- A full `check_all` sweep has not run yet, so the HTTP-level picture for the remaining links is still the one from #318, taken before the widened `GET` fallback. That needs a manual dispatch.
- `nordicdesign.gallery` returns `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`, an incomplete certificate chain. That often renders fine in a browser while failing programmatic clients, so it needs a human look before choosing between a fix, an acknowledgement or a removal.

## Note

The `lint-staged` prettier hook rewrites frontmatter quotes from `"..."` to `'...'` on any collection file it touches. Both are valid YAML and nothing breaks, but it accounts for a cosmetic line in several of these diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5A9G9Uy2FCLCeq1NEmYYw