### PR TITLE
Use absolute URLs across machine-readable output

### DIFF
--- a/app/(blog)/notes/[...slug]/page.js
+++ b/app/(blog)/notes/[...slug]/page.js
@@ -50,6 +50,9 @@ export async function generateMetadata(props) {
     description: note.summary ?? '',
     alternates: {
       canonical: note.slug,
+      types: {
+        'text/markdown': `/api/content/notes/${note.slugAsParams}`,
+      },
     },
     openGraph: {
       title: note.title,

--- a/app/(post)/blog/[...slug]/page.js
+++ b/app/(post)/blog/[...slug]/page.js
@@ -42,6 +42,9 @@ export async function generateMetadata(props) {
     description: post.metadesc,
     alternates: {
       canonical: post.slug,
+      types: {
+        'text/markdown': `/api/content/${post.slugAsParams}`,
+      },
     },
     openGraph: {
       title: post.title,

--- a/app/llms.txt/route.js
+++ b/app/llms.txt/route.js
@@ -1,5 +1,6 @@
 import { allPosts } from 'content-collections'
 import { createClient } from '@supabase/supabase-js'
+import siteMetadata from '@/content/metadata'
 
 export const revalidate = 86400 // Revalidate daily
 export const dynamic = 'force-static'
@@ -48,25 +49,32 @@ export async function GET() {
     ...new Map([...topByViews, ...mostRecent].map((p) => [p.slug, p])).values(),
   ]
 
+  const base = siteMetadata.siteUrl
+
   const content = `# iamsteve.me
 
 > Tips and tutorials about the design and build of web interfaces. Through design and code tutorials focused on maintainable CSS, good typography and UI fundamentals by Steve McKinney.
 
 ## Best articles
 
-${featured.map((post) => `- [${post.title}](${post.slug})`).join('\n')}
+${featured
+  .map(
+    (post) =>
+      `- [${post.title}](${base}${post.slug}): markdown at ${base}/api/content/${post.slugAsParams}`
+  )
+  .join('\n')}
 
 ## Categories
 
-- [Design articles](/category/design)
-- [Code articles](/category/code)
-- [Typography articles](/category/typography)
+- [Design articles](${base}/category/design)
+- [Code articles](${base}/category/code)
+- [Typography articles](${base}/category/typography)
 
 ## Optional
 
-- [Full archive](/blog)
-- [RSS feed](/feed.xml)
-- [About](/about)
+- [Full archive](${base}/blog)
+- [RSS feed](${base}/feed.xml)
+- [About](${base}/about)
 `
 
   return new Response(content, {

--- a/lib/compile-mdx-for-rss.js
+++ b/lib/compile-mdx-for-rss.js
@@ -7,12 +7,24 @@
 
 import { rssComponents } from './rss-components.js'
 import { marked } from 'marked'
+import siteMetadata from '../content/metadata.js'
 
 // Configure marked to not escape HTML entities
 marked.setOptions({
   mangle: false,
   headerIds: false,
 })
+
+/**
+ * Rewrite root-relative hrefs and srcs to absolute URLs. Feed readers show the
+ * markup outside the site, so they have no base URL to resolve against.
+ */
+function absoluteUrls(html) {
+  return html.replace(
+    /(href|src)="(\/(?!\/)[^"]*)"/g,
+    `$1="${siteMetadata.siteUrl}$2"`
+  )
+}
 
 /**
  * Simple JSX component parser and replacer
@@ -231,5 +243,5 @@ export function compileMdxForRssWithMarked(mdxContent) {
   } while (content !== prev)
 
   // Then use marked to convert markdown to HTML
-  return marked(content)
+  return absoluteUrls(marked(content))
 }

--- a/lib/utils/clean-markdown-for-llms.js
+++ b/lib/utils/clean-markdown-for-llms.js
@@ -1,3 +1,13 @@
+import siteMetadata from '@/content/metadata'
+
+/**
+ * Rewrite root-relative markdown links and images to absolute URLs. The
+ * markdown is served standalone, so there is no document to resolve against.
+ */
+function absoluteLinks(text) {
+  return text.replace(/\]\((\/(?!\/)[^)]*)\)/g, `](${siteMetadata.siteUrl}$1)`)
+}
+
 /**
  * Clean markdown for LLM consumption by removing custom React components
  * and converting them to simple markdown equivalents
@@ -67,7 +77,7 @@ export function cleanMarkdownForLLMs(markdown) {
           caption = caption.replace(/<p>/g, '').replace(/<\/p>/g, '')
           // Transform <Fig>N</Fig> to **Figure N**
           caption = caption.replace(/<Fig>(\d+)<\/Fig>/g, '**Figure $1**')
-          figcaption = caption.trim()
+          figcaption = absoluteLinks(caption.trim())
         }
       }
       continue
@@ -104,6 +114,8 @@ export function cleanMarkdownForLLMs(markdown) {
       /<Demo\s+src="([^"]+)"\s*\/>/g,
       '[View interactive demo]($1)'
     )
+
+    line = absoluteLinks(line)
 
     // Remove <Image> tags entirely (single line)
     line = line.replace(/<Image\s+[^>]*\/>/g, '')


### PR DESCRIPTION
Relative links have no base to resolve against once content is served
outside a page, so llms.txt, the markdown API and the RSS feed all handed
consumers hrefs they could not follow.

- llms.txt now emits absolute URLs throughout, and lists the markdown
  version of each article alongside the HTML one
- cleanMarkdownForLLMs rewrites root-relative links and images, leaving
  fenced code, anchors, external and protocol-relative URLs untouched
- the RSS body absolutises hrefs and srcs after markdown compilation,
  which also fixes broken links and images in feed readers
- post and note pages advertise their markdown twin via
  rel="alternate" type="text/markdown"

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01W2hKNLqf1YVGTHumLeu5r6