### PR TITLE
Improve agent readiness across the site

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run tests
+        run: pnpm test

--- a/app/(blog)/notes/[...slug]/page.js
+++ b/app/(blog)/notes/[...slug]/page.js
@@ -50,6 +50,9 @@ export async function generateMetadata(props) {
     description: note.summary ?? '',
     alternates: {
       canonical: note.slug,
+      types: {
+        'text/markdown': `/api/content/notes/${note.slugAsParams}`,
+      },
     },
     openGraph: {
       title: note.title,

--- a/app/(blog)/notes/[...slug]/page.js
+++ b/app/(blog)/notes/[...slug]/page.js
@@ -18,6 +18,11 @@ import Link from '@/components/link'
 
 export const revalidate = 86400
 
+// Every renderable slug is prerendered below, so anything else is a 404.
+// Saying so up front means Next serves the prerendered not-found page
+// instead of an empty shell that only fills in once JavaScript runs.
+export const dynamicParams = false
+
 export async function generateStaticParams() {
   return allNotes
     .filter((note) => note.status === 'published')

--- a/app/(page)/[...slug]/page.js
+++ b/app/(page)/[...slug]/page.js
@@ -39,6 +39,11 @@ export async function generateMetadata(props) {
   }
 }
 
+// Every renderable slug is prerendered below, so anything else is a 404.
+// Saying so up front means Next serves the prerendered not-found page
+// instead of an empty shell that only fills in once JavaScript runs.
+export const dynamicParams = false
+
 export async function generateStaticParams() {
   return allPages.map((page) => ({
     slug: page.slugAsParams.split('/'),

--- a/app/(page)/collections/[...slug]/page.js
+++ b/app/(page)/collections/[...slug]/page.js
@@ -73,6 +73,11 @@ export async function generateMetadata(props) {
   }
 }
 
+// Every renderable slug is prerendered below, so anything else is a 404.
+// Saying so up front means Next serves the prerendered not-found page
+// instead of an empty shell that only fills in once JavaScript runs.
+export const dynamicParams = false
+
 export async function generateStaticParams() {
   return collections.map((page) => ({
     slug: page.slugAsParams.split('/'),

--- a/app/(post)/blog/[...slug]/page.js
+++ b/app/(post)/blog/[...slug]/page.js
@@ -42,6 +42,9 @@ export async function generateMetadata(props) {
     description: post.metadesc,
     alternates: {
       canonical: post.slug,
+      types: {
+        'text/markdown': `/api/content/${post.slugAsParams}`,
+      },
     },
     openGraph: {
       title: post.title,

--- a/app/(post)/blog/[...slug]/page.js
+++ b/app/(post)/blog/[...slug]/page.js
@@ -12,6 +12,11 @@ import PostBody from './post-body'
 
 export const revalidate = 86400
 
+// Every renderable slug is prerendered below, so anything else is a 404.
+// Saying so up front means Next serves the prerendered not-found page
+// instead of an empty shell that only fills in once JavaScript runs.
+export const dynamicParams = false
+
 export async function generateStaticParams() {
   return allPosts
     .filter((post) => post.status === 'open' || post.status === 'unlisted')

--- a/app/.well-known/api-catalog/route.js
+++ b/app/.well-known/api-catalog/route.js
@@ -14,6 +14,13 @@ export async function GET() {
     linkset: [
       {
         anchor: `${base}/api/content`,
+        'service-desc': [
+          {
+            href: `${base}/openapi.json`,
+            type: 'application/json',
+            title: 'OpenAPI description of the whole API',
+          },
+        ],
         'service-doc': [
           {
             href: `${base}/llms.txt`,
@@ -22,6 +29,11 @@ export async function GET() {
           },
         ],
         item: [
+          {
+            href: `${base}/api/content/home`,
+            title: 'Get the homepage as markdown',
+            type: 'text/markdown',
+          },
           {
             href: `${base}/api/content/{slug}`,
             title: 'Get a blog article as markdown',
@@ -32,10 +44,27 @@ export async function GET() {
             title: 'Get a note as markdown',
             type: 'text/markdown',
           },
+          {
+            href: `${base}/api/content/pages/{slug}`,
+            title: 'Get a standalone page as markdown',
+            type: 'text/markdown',
+          },
+          {
+            href: `${base}/api/content/collections/{slug}`,
+            title: 'Get a collection entry as markdown',
+            type: 'text/markdown',
+          },
         ],
       },
       {
         anchor: `${base}/api/newsletter`,
+        'service-desc': [
+          {
+            href: `${base}/openapi.json`,
+            type: 'application/json',
+            title: 'OpenAPI description of the whole API',
+          },
+        ],
         item: [
           {
             href: `${base}/api/newsletter`,

--- a/app/api/[...path]/route.js
+++ b/app/api/[...path]/route.js
@@ -1,0 +1,26 @@
+import siteMetadata from '@/content/metadata'
+import { apiError } from '@/lib/agent/errors'
+
+/**
+ * Anything under /api that no other route claims. Without this an unknown API
+ * path falls through to the HTML 404 page, which an agent cannot parse.
+ */
+const notFound = async (request, { params }) => {
+  const { path } = await params
+
+  return apiError({
+    status: 404,
+    code: 'NOT_FOUND',
+    message: `There is no API endpoint at /api/${path.join('/')}.`,
+    hint: `Every available endpoint is described at ${siteMetadata.siteUrl}/openapi.json.`,
+    headers: { 'Access-Control-Allow-Origin': '*' },
+  })
+}
+
+export const GET = notFound
+export const POST = notFound
+export const PUT = notFound
+export const PATCH = notFound
+export const DELETE = notFound
+export const HEAD = notFound
+export const OPTIONS = notFound

--- a/app/api/campaigns/route.js
+++ b/app/api/campaigns/route.js
@@ -1,15 +1,19 @@
 /* eslint import/no-anonymous-default-export: "off" */
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/agent/errors'
+
 export const GET = async (req) => {
   const API_URL = process.env.EMAILOCTOPUS_API_URL
   const API_KEY = process.env.EMAILOCTOPUS_API_KEY
 
   if (!API_URL || !API_KEY) {
-    return NextResponse.json(
-      { error: 'API configuration missing' },
-      { status: 500 }
-    )
+    return apiError({
+      status: 500,
+      code: 'NEWSLETTER_NOT_CONFIGURED',
+      message: 'The newsletter provider is not configured on this deployment.',
+      hint: 'Read the published issues at https://iamsteve.me/newsletter instead.',
+    })
   }
 
   const API_ROUTE = `${API_URL}campaigns?api_key=${API_KEY}&limit=12`
@@ -25,17 +29,21 @@ export const GET = async (req) => {
     const data = await res.json()
 
     if (!res.ok) {
-      return NextResponse.json(
-        { error: data.error?.message || 'Failed to fetch campaigns' },
-        { status: res.status }
-      )
+      return apiError({
+        status: res.status,
+        code: 'CAMPAIGNS_UNAVAILABLE',
+        message: data.error?.message || 'The issue list could not be fetched.',
+        hint: 'This is a temporary fault at our end. Retry in a few minutes.',
+      })
     }
 
     return NextResponse.json(data)
   } catch (error) {
-    return NextResponse.json(
-      { error: error.message || 'Failed to fetch campaigns' },
-      { status: 500 }
-    )
+    return apiError({
+      status: 500,
+      code: 'CAMPAIGNS_UNAVAILABLE',
+      message: error.message || 'The issue list could not be fetched.',
+      hint: 'This is a temporary fault at our end. Retry in a few minutes.',
+    })
   }
 }

--- a/app/api/content/[slug]/route.js
+++ b/app/api/content/[slug]/route.js
@@ -1,18 +1,13 @@
 import { allPosts } from 'content-collections'
 import { cleanMarkdownForLLMs } from '@/lib/utils/clean-markdown-for-llms'
+import { markdownHeaders, markdownNotFound } from '@/lib/agent/markdown'
 
 export async function GET(request, { params }) {
   const { slug } = await params
   const post = allPosts.find((p) => p.slug === `/blog/${slug}`)
 
   if (!post) {
-    return new Response(
-      '# Not Found\n\nThe requested article does not exist.',
-      {
-        status: 404,
-        headers: { 'Content-Type': 'text/markdown; charset=utf-8' },
-      }
-    )
+    return markdownNotFound(`/blog/${slug}`)
   }
 
   const cleanedMarkdown = cleanMarkdownForLLMs(post.content)
@@ -35,10 +30,5 @@ export async function GET(request, { params }) {
 
   const output = `${frontmatter}\n\n${cleanedMarkdown}`
 
-  return new Response(output, {
-    headers: {
-      'Content-Type': 'text/markdown; charset=utf-8',
-      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
-    },
-  })
+  return new Response(output, { headers: markdownHeaders })
 }

--- a/app/api/content/collections/[slug]/route.js
+++ b/app/api/content/collections/[slug]/route.js
@@ -1,0 +1,57 @@
+import { allCollections } from 'content-collections'
+
+import collections from '@/content/collections'
+import siteMetadata from '@/content/metadata'
+import { markdownHeaders, markdownNotFound } from '@/lib/agent/markdown'
+
+export async function GET(request, { params }) {
+  const { slug } = await params
+  const collection = collections.find((c) => c.slugAsParams === slug)
+
+  if (!collection) {
+    return markdownNotFound(`/collections/${slug}`)
+  }
+
+  // The same match the HTML page makes, so both representations agree.
+  const entries = allCollections
+    .filter((entry) =>
+      entry.collection?.some(
+        (name) => name.toLowerCase() === slug.toLowerCase()
+      )
+    )
+    .sort((a, b) => new Date(b.date) - new Date(a.date))
+
+  const frontmatter = [
+    '---',
+    `title: "${collection.title.replace(/"/g, '\\"')}"`,
+    `description: "Curated design resources about ${collection.title.toLowerCase()}."`,
+    `count: ${entries.length}`,
+    `url: ${siteMetadata.siteUrl}/collections/${slug}`,
+    '---',
+  ].join('\n')
+
+  const body = entries
+    .map(
+      (entry) =>
+        `- [${entry.title}](${entry.url}): added ${entry.date.slice(0, 10)}`
+    )
+    .join('\n')
+
+  const output = `${frontmatter}
+
+# ${collection.title}
+
+Curated design resources about ${collection.title.toLowerCase()}, collected on
+[iamsteve.me](${siteMetadata.siteUrl}/collections).
+
+${body || 'Nothing collected here yet.'}
+
+## Other collections
+
+${collections
+  .map((c) => `- [${c.title}](${siteMetadata.siteUrl}${c.slug})`)
+  .join('\n')}
+`
+
+  return new Response(output, { headers: markdownHeaders })
+}

--- a/app/api/content/home/route.js
+++ b/app/api/content/home/route.js
@@ -2,6 +2,7 @@ import { allPosts } from 'content-collections'
 import { createClient } from '@supabase/supabase-js'
 
 import siteMetadata from '@/content/metadata'
+import { MARKDOWN_VARY } from '@/lib/agent/markdown'
 
 export const revalidate = 86400
 export const dynamic = 'force-static'
@@ -73,12 +74,14 @@ ${popular.map(line).join('\n')}
 
 - [RSS feed](${siteMetadata.siteUrl}/feed.xml)
 - [llms.txt](${siteMetadata.siteUrl}/llms.txt)
+- [OpenAPI description](${siteMetadata.siteUrl}/openapi.json)
 `
 
   return new Response(markdown, {
     headers: {
       'Content-Type': 'text/markdown; charset=utf-8',
       'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+      Vary: MARKDOWN_VARY,
     },
   })
 }

--- a/app/api/content/pages/[slug]/route.js
+++ b/app/api/content/pages/[slug]/route.js
@@ -1,24 +1,25 @@
-import { allNotes } from 'content-collections'
+import { allPages } from 'content-collections'
 import { cleanMarkdownForLLMs } from '@/lib/utils/clean-markdown-for-llms'
 import { markdownHeaders, markdownNotFound } from '@/lib/agent/markdown'
 
 export async function GET(request, { params }) {
   const { slug } = await params
-  const note = allNotes.find((n) => n.slug === `/notes/${slug}`)
+  const page = allPages.find((p) => p.slugAsParams === slug)
 
-  if (!note) {
-    return markdownNotFound(`/notes/${slug}`)
+  if (!page) {
+    return markdownNotFound(`/${slug}`)
   }
 
-  const cleanedMarkdown = cleanMarkdownForLLMs(note.content)
+  const cleanedMarkdown = cleanMarkdownForLLMs(page.content)
 
   const frontmatter = [
     '---',
-    `title: "${note.title.replace(/"/g, '\\"')}"`,
+    `title: "${page.title.replace(/"/g, '\\"')}"`,
     `author: Steve McKinney`,
-    `date: ${note.date}`,
-    note.summary ? `summary: "${note.summary.replace(/"/g, '\\"')}"` : null,
-    `url: https://iamsteve.me${note.slug}`,
+    page.description
+      ? `description: "${page.description.replace(/"/g, '\\"')}"`
+      : null,
+    `url: https://iamsteve.me/${slug}`,
     '---',
   ]
     .filter(Boolean)

--- a/app/api/newsletter/route.js
+++ b/app/api/newsletter/route.js
@@ -1,14 +1,34 @@
 import { NextResponse } from 'next/server'
 
+import { apiError } from '@/lib/agent/errors'
+
 const API_URL = process.env.EMAILOCTOPUS_API_URL
 const API_KEY = process.env.EMAILOCTOPUS_API_KEY
 const LIST_ID = process.env.EMAILOCTOPUS_LIST_ID
 
 export const POST = async (req) => {
-  const { email, name, source } = await req.json()
+  let body
+
+  try {
+    body = await req.json()
+  } catch {
+    return apiError({
+      status: 400,
+      code: 'INVALID_JSON',
+      message: 'The request body could not be parsed as JSON.',
+      hint: 'Send a JSON body and set Content-Type: application/json.',
+    })
+  }
+
+  const { email, name, source } = body
 
   if (!email) {
-    return NextResponse.json({ error: 'Email is required' }, { status: 400 })
+    return apiError({
+      status: 400,
+      code: 'EMAIL_REQUIRED',
+      message: 'An email address is required to subscribe.',
+      hint: 'Include an "email" field in the JSON body.',
+    })
   }
 
   const config = {
@@ -37,10 +57,12 @@ export const POST = async (req) => {
     if (res.ok) {
       return NextResponse.json({ success: true })
     } else if (data.error?.code === 'MEMBER_EXISTS_WITH_EMAIL_ADDRESS') {
-      return NextResponse.json(
-        { error: 'MEMBER_EXISTS_WITH_EMAIL_ADDRESS' },
-        { status: 400 }
-      )
+      return apiError({
+        status: 400,
+        code: 'MEMBER_EXISTS_WITH_EMAIL_ADDRESS',
+        message: 'That email address is already subscribed.',
+        hint: 'No action needed. Check the inbox for the confirmation email.',
+      })
     } else {
       if (process.env.NODE_ENV !== 'production') {
         console.error(
@@ -48,15 +70,23 @@ export const POST = async (req) => {
           data.error?.message || 'Unknown error'
         )
       }
-      return NextResponse.json(
-        { error: data.error?.message || 'Subscription failed' },
-        { status: res.status }
-      )
+      return apiError({
+        status: res.status,
+        code: 'SUBSCRIPTION_FAILED',
+        message:
+          data.error?.message || 'The subscription could not be created.',
+        hint: 'Check the email address is valid, then try again.',
+      })
     }
   } catch (error) {
     if (process.env.NODE_ENV !== 'production') {
       console.error('Subscription error:', error.message)
     }
-    return NextResponse.json({ error: error.message }, { status: 500 })
+    return apiError({
+      status: 500,
+      code: 'NEWSLETTER_UNAVAILABLE',
+      message: 'The newsletter provider could not be reached.',
+      hint: 'This is a temporary fault at our end. Retry in a few minutes.',
+    })
   }
 }

--- a/app/llms.txt/route.js
+++ b/app/llms.txt/route.js
@@ -75,6 +75,8 @@ ${featured
 - [Full archive](${base}/blog)
 - [RSS feed](${base}/feed.xml)
 - [About](${base}/about)
+- [OpenAPI description](${base}/openapi.json)
+- [API catalog](${base}/.well-known/api-catalog)
 `
 
   return new Response(content, {

--- a/app/llms.txt/route.js
+++ b/app/llms.txt/route.js
@@ -1,5 +1,6 @@
 import { allPosts } from 'content-collections'
 import { createClient } from '@supabase/supabase-js'
+import siteMetadata from '@/content/metadata'
 
 export const revalidate = 86400 // Revalidate daily
 export const dynamic = 'force-static'
@@ -48,25 +49,32 @@ export async function GET() {
     ...new Map([...topByViews, ...mostRecent].map((p) => [p.slug, p])).values(),
   ]
 
+  const base = siteMetadata.siteUrl
+
   const content = `# iamsteve.me
 
 > Tips and tutorials about the design and build of web interfaces. Through design and code tutorials focused on maintainable CSS, good typography and UI fundamentals by Steve McKinney.
 
 ## Best articles
 
-${featured.map((post) => `- [${post.title}](${post.slug})`).join('\n')}
+${featured
+  .map(
+    (post) =>
+      `- [${post.title}](${base}${post.slug}): markdown at ${base}/api/content/${post.slugAsParams}`
+  )
+  .join('\n')}
 
 ## Categories
 
-- [Design articles](/category/design)
-- [Code articles](/category/code)
-- [Typography articles](/category/typography)
+- [Design articles](${base}/category/design)
+- [Code articles](${base}/category/code)
+- [Typography articles](${base}/category/typography)
 
 ## Optional
 
-- [Full archive](/blog)
-- [RSS feed](/feed.xml)
-- [About](/about)
+- [Full archive](${base}/blog)
+- [RSS feed](${base}/feed.xml)
+- [About](${base}/about)
 `
 
   return new Response(content, {

--- a/app/not-found.js
+++ b/app/not-found.js
@@ -1,5 +1,6 @@
 import Link from '@/components/link'
 import Button from '@/components/button'
+import { recoveryLinks } from '@/lib/agent/not-found'
 
 export default function NotFound() {
   return (
@@ -23,6 +24,29 @@ export default function NotFound() {
       >
         Back to homepage
       </Button>
+      <section
+        className="col-content flex flex-col gap-4"
+        aria-labelledby="recovery"
+      >
+        <h2
+          id="recovery"
+          className="font-display text-heading text-2xl font-variation-bold lowercase"
+        >
+          Where to look next
+        </h2>
+        <ul className="flex flex-col gap-2 text-ui-body max-w-prose">
+          {recoveryLinks
+            .filter((link) => link.href !== '/')
+            .map((link) => (
+              <li key={link.href}>
+                <Link href={link.href} className="text-underline">
+                  {link.title}
+                </Link>
+                &thinsp;&mdash;&thinsp;{link.description}
+              </li>
+            ))}
+        </ul>
+      </section>
     </div>
   )
 }

--- a/app/openapi.json/route.js
+++ b/app/openapi.json/route.js
@@ -1,0 +1,419 @@
+import siteMetadata from '@/content/metadata'
+
+export const revalidate = 86400
+export const dynamic = 'force-static'
+
+const base = siteMetadata.siteUrl
+
+const markdownResponse = (description) => ({
+  description,
+  headers: {
+    Vary: {
+      description:
+        'Includes `Accept` so caches keep the markdown and HTML variants apart.',
+      schema: { type: 'string' },
+    },
+  },
+  content: {
+    'text/markdown': {
+      schema: {
+        type: 'string',
+        description: 'Markdown with YAML frontmatter.',
+      },
+    },
+  },
+})
+
+const errorResponse = (description) => ({
+  description,
+  content: {
+    'application/json': {
+      schema: { $ref: '#/components/schemas/Error' },
+    },
+  },
+})
+
+const slugParameter = {
+  name: 'slug',
+  in: 'path',
+  required: true,
+  description: 'The final path segment of the URL, without a leading slash.',
+  schema: { type: 'string' },
+  example: 'kerning-vs-tracking',
+}
+
+const spec = {
+  openapi: '3.1.0',
+  info: {
+    title: 'iamsteve.me',
+    version: '1.0.0',
+    summary: 'Read articles as markdown and subscribe to the newsletter.',
+    description: `The public HTTP surface of [iamsteve.me](${base}).
+
+Every HTML page that has a markdown representation can also be requested with
+an \`Accept: text/markdown\` header, or by appending \`.md\` to the URL. Those
+responses send \`Vary: Accept, Accept-Encoding\` so shared caches keep the two
+representations apart.
+
+Errors are always JSON in the shape described by the \`Error\` schema, with a
+stable \`code\`, a human readable \`message\`, and a \`hint\` describing how to
+recover.`,
+    contact: {
+      name: 'Steve McKinney',
+      url: `${base}/contact`,
+      email: siteMetadata.email,
+    },
+    license: {
+      name: 'MIT',
+      url: `${siteMetadata.siteRepo}/blob/main/LICENSE`,
+    },
+  },
+  servers: [{ url: base, description: 'Production' }],
+  externalDocs: {
+    description: 'LLM-friendly index of the site',
+    url: `${base}/llms.txt`,
+  },
+  tags: [
+    { name: 'content', description: 'Articles, notes and pages as markdown' },
+    { name: 'newsletter', description: 'Newsletter subscription and archive' },
+    { name: 'discovery', description: 'Machine-readable indexes and feeds' },
+  ],
+  paths: {
+    '/api/content/home': {
+      get: {
+        tags: ['content'],
+        operationId: 'getHomeMarkdown',
+        summary: 'Homepage as markdown',
+        description:
+          'Latest and most-read articles, with links to the rest of the site. Also served for `GET /` when the request accepts `text/markdown`.',
+        responses: {
+          200: markdownResponse('Markdown index of the site.'),
+        },
+      },
+    },
+    '/api/content/{slug}': {
+      get: {
+        tags: ['content'],
+        operationId: 'getArticleMarkdown',
+        summary: 'Blog article as markdown',
+        description:
+          'The source markdown for a blog article, with custom components flattened. Also served for `GET /blog/{slug}` when the request accepts `text/markdown`.',
+        parameters: [slugParameter],
+        responses: {
+          200: markdownResponse('The article body with YAML frontmatter.'),
+          404: {
+            description: 'No article with that slug.',
+            content: {
+              'text/markdown': {
+                schema: {
+                  type: 'string',
+                  description:
+                    'A markdown 404 listing where to look next, including the sitemap and llms.txt.',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/content/notes/{slug}': {
+      get: {
+        tags: ['content'],
+        operationId: 'getNoteMarkdown',
+        summary: 'Note as markdown',
+        description:
+          'Also served for `GET /notes/{slug}` when the request accepts `text/markdown`.',
+        parameters: [slugParameter],
+        responses: {
+          200: markdownResponse('The note body with YAML frontmatter.'),
+          404: {
+            description: 'No note with that slug.',
+            content: {
+              'text/markdown': { schema: { type: 'string' } },
+            },
+          },
+        },
+      },
+    },
+    '/api/content/pages/{slug}': {
+      get: {
+        tags: ['content'],
+        operationId: 'getPageMarkdown',
+        summary: 'Standalone page as markdown',
+        description:
+          'Pages such as `about` and `uses`. Also served for `GET /{slug}` when the request accepts `text/markdown`.',
+        parameters: [{ ...slugParameter, example: 'about' }],
+        responses: {
+          200: markdownResponse('The page body with YAML frontmatter.'),
+          404: {
+            description: 'No page with that slug.',
+            content: {
+              'text/markdown': { schema: { type: 'string' } },
+            },
+          },
+        },
+      },
+    },
+    '/api/content/collections/{slug}': {
+      get: {
+        tags: ['content'],
+        operationId: 'getCollectionMarkdown',
+        summary: 'Collection listing as markdown',
+        description:
+          'Every curated link filed under one collection. Also served for `GET /collections/{slug}` when the request accepts `text/markdown`.',
+        parameters: [{ ...slugParameter, example: 'colour' }],
+        responses: {
+          200: markdownResponse('The entry with YAML frontmatter.'),
+          404: {
+            description: 'No collection with that slug.',
+            content: {
+              'text/markdown': { schema: { type: 'string' } },
+            },
+          },
+        },
+      },
+    },
+    '/api/newsletter': {
+      post: {
+        tags: ['newsletter'],
+        operationId: 'subscribe',
+        summary: 'Subscribe to the newsletter',
+        description:
+          'The list is double opt-in, so the address receives a confirmation email before it is added. Confirm the person actually wants this before calling it.',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: { $ref: '#/components/schemas/SubscribeRequest' },
+            },
+          },
+        },
+        responses: {
+          200: {
+            description: 'Subscription created and confirmation email sent.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { success: { type: 'boolean', const: true } },
+                  required: ['success'],
+                },
+              },
+            },
+          },
+          400: errorResponse(
+            'Missing or malformed body (`EMAIL_REQUIRED`, `INVALID_JSON`), or the address is already subscribed (`MEMBER_EXISTS_WITH_EMAIL_ADDRESS`).'
+          ),
+          500: errorResponse('The newsletter provider could not be reached.'),
+        },
+      },
+    },
+    '/api/newsletter/count': {
+      get: {
+        tags: ['newsletter'],
+        operationId: 'getSubscriberCount',
+        summary: 'Subscriber count',
+        description:
+          'Falls back to a floor value rather than erroring when the provider is unavailable, because it only drives display copy.',
+        responses: {
+          200: {
+            description: 'Current confirmed subscriber count.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { count: { type: 'integer', minimum: 0 } },
+                  required: ['count'],
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    '/api/campaigns': {
+      get: {
+        tags: ['newsletter'],
+        operationId: 'listCampaigns',
+        summary: 'Recent newsletter issues',
+        responses: {
+          200: {
+            description: 'The twelve most recent issues.',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    data: {
+                      type: 'array',
+                      items: { $ref: '#/components/schemas/Campaign' },
+                    },
+                  },
+                },
+              },
+            },
+          },
+          500: errorResponse(
+            'The newsletter provider is unavailable or unconfigured.'
+          ),
+        },
+      },
+    },
+    '/llms.txt': {
+      get: {
+        tags: ['discovery'],
+        operationId: 'getLlmsTxt',
+        summary: 'LLM-friendly content index',
+        responses: {
+          200: {
+            description: 'Best and most recent articles, with markdown links.',
+            content: { 'text/plain': { schema: { type: 'string' } } },
+          },
+        },
+      },
+    },
+    '/feed.xml': {
+      get: {
+        tags: ['discovery'],
+        operationId: 'getFeed',
+        summary: 'RSS feed of posts and notes',
+        responses: {
+          200: {
+            description: 'RSS 2.0 feed.',
+            content: { 'application/rss+xml': { schema: { type: 'string' } } },
+          },
+        },
+      },
+    },
+    '/sitemap.xml': {
+      get: {
+        tags: ['discovery'],
+        operationId: 'getSitemap',
+        summary: 'Sitemap of every indexable URL',
+        responses: {
+          200: {
+            description: 'urlset sitemap.',
+            content: { 'application/xml': { schema: { type: 'string' } } },
+          },
+        },
+      },
+    },
+    '/.well-known/api-catalog': {
+      get: {
+        tags: ['discovery'],
+        operationId: 'getApiCatalog',
+        summary: 'RFC 9727 API catalog',
+        responses: {
+          200: {
+            description: 'A linkset describing the APIs this site offers.',
+            content: {
+              'application/linkset+json': { schema: { type: 'object' } },
+            },
+          },
+        },
+      },
+    },
+    '/.well-known/agent-skills/index.json': {
+      get: {
+        tags: ['discovery'],
+        operationId: 'getAgentSkills',
+        summary: 'Agent skills index',
+        responses: {
+          200: {
+            description: 'Skills an agent can load to work with this site.',
+            content: { 'application/json': { schema: { type: 'object' } } },
+          },
+        },
+      },
+    },
+    '/openapi.json': {
+      get: {
+        tags: ['discovery'],
+        operationId: 'getOpenapi',
+        summary: 'This description document',
+        responses: {
+          200: {
+            description: 'The OpenAPI description of this API.',
+            content: { 'application/json': { schema: { type: 'object' } } },
+          },
+        },
+      },
+    },
+  },
+  components: {
+    schemas: {
+      Error: {
+        type: 'object',
+        description: 'The shape every API error uses.',
+        properties: {
+          error: {
+            type: 'object',
+            properties: {
+              code: {
+                type: 'string',
+                description:
+                  'Stable, machine-readable identifier for the failure.',
+                examples: ['EMAIL_REQUIRED', 'NOT_FOUND'],
+              },
+              message: {
+                type: 'string',
+                description: 'What went wrong, in plain English.',
+              },
+              hint: {
+                type: 'string',
+                description: 'What to do about it.',
+              },
+              status: {
+                type: 'integer',
+                description: 'The HTTP status code, repeated for convenience.',
+              },
+              documentation: {
+                type: 'string',
+                format: 'uri',
+                description: 'Where the API is described.',
+              },
+            },
+            required: ['code', 'message', 'hint', 'status'],
+          },
+        },
+        required: ['error'],
+      },
+      SubscribeRequest: {
+        type: 'object',
+        properties: {
+          email: {
+            type: 'string',
+            format: 'email',
+            description: 'The address to subscribe.',
+          },
+          name: { type: 'string', description: 'First name, optional.' },
+          source: {
+            type: 'string',
+            description:
+              'Free-form label for where the subscription came from.',
+          },
+        },
+        required: ['email'],
+      },
+      Campaign: {
+        type: 'object',
+        properties: {
+          id: { type: 'string' },
+          subject: { type: 'string' },
+          status: { type: 'string', examples: ['SENT'] },
+          sent_at: { type: 'string', format: 'date-time' },
+        },
+      },
+    },
+  },
+}
+
+export async function GET() {
+  return new Response(JSON.stringify(spec, null, 2), {
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+      'Access-Control-Allow-Origin': '*',
+    },
+  })
+}

--- a/components/card/container.js
+++ b/components/card/container.js
@@ -61,7 +61,12 @@ const PostImage = ({ ...props }) => {
   )
 }
 
-const Container = ({ frontmatter, image, className = 'card' }) => {
+const Container = ({
+  frontmatter,
+  image,
+  className = 'card',
+  headingLevel = 2,
+}) => {
   const {
     slug,
     date,
@@ -84,6 +89,10 @@ const Container = ({ frontmatter, image, className = 'card' }) => {
   // [mask:radial-gradient(155%_140%_at_50%_30%,#fff_24.1%,rgba(255,255,255,0.56)_41.94%,transparent_48.59%,transparent_100%)]
   // [mask:linear-gradient(to_right,#fff_75%,#fff_80%,transparent_97.5%)]
   //  [mask:radial-gradient(163.02%_100%_at_50%_0%,#fff_83.77%,rgba(255,255,255,0.8)_90.28%,transparent_100%)]
+
+  // Cards sit under a section heading on the homepage and under the page
+  // heading elsewhere, so the level has to follow the outline.
+  const Heading = 'h' + headingLevel
 
   const imageColor = theme ? theme.toString() : '#f1e8e4'
   const imageClass = `relative flex items-center justify-center`
@@ -170,7 +179,7 @@ const Container = ({ frontmatter, image, className = 'card' }) => {
           </Badge>
         </div>
         <div className="flex flex-col gap-2.5 px-8 pt-[.8125rem] @lg/card:pt-2 @lg/card:gap-3 @lg/card:px-12">
-          <h2
+          <Heading
             className="p-0 m-0 leading-none text-balance lowercase font-display font-variation-bold hyphens-auto text-3xl @lg/card:text-5xl"
             id={`title-${_meta?.filePath}`}
           >
@@ -180,7 +189,7 @@ const Container = ({ frontmatter, image, className = 'card' }) => {
             >
               {title}
             </Link>
-          </h2>
+          </Heading>
           {summary && (
             <div
               className="flex-auto md:text-lg text-ui-body line-clamp-4 @lg/card:line-clamp-3"

--- a/components/card/index.js
+++ b/components/card/index.js
@@ -3,7 +3,13 @@ import Large from './large'
 import Medium from './medium'
 import Small from './small'
 
-const Card = ({ size = 'medium', image, frontmatter, className }) => {
+const Card = ({
+  size = 'medium',
+  image,
+  frontmatter,
+  className,
+  headingLevel,
+}) => {
   return (
     <>
       {size === 'container' && (
@@ -11,6 +17,7 @@ const Card = ({ size = 'medium', image, frontmatter, className }) => {
           image={image}
           frontmatter={frontmatter}
           className={className}
+          headingLevel={headingLevel}
         />
       )}
       {size === 'large' && (

--- a/components/newsletter-form.js
+++ b/components/newsletter-form.js
@@ -60,7 +60,7 @@ const NewsletterForm = ({
         setMessage(`The server cannot be reached to submit your request.`)
       } else if (
         res.status === 400 &&
-        data.error === 'MEMBER_EXISTS_WITH_EMAIL_ADDRESS'
+        data.error?.code === 'MEMBER_EXISTS_WITH_EMAIL_ADDRESS'
       ) {
         setError(true)
         setMessage(`This email is already subscribed to the newsletter.`)

--- a/components/posts/latest.js
+++ b/components/posts/latest.js
@@ -19,6 +19,7 @@ export default function LatestPosts({ posts, title, linkText, linkHref }) {
             frontmatter={post}
             image={true}
             key={post._meta?.filePath}
+            headingLevel={3}
             className="max-sm:w-[calc(100vw-48px)] max-sm:snap-center md:col-span-1"
           />
         ))}

--- a/components/posts/popular.js
+++ b/components/posts/popular.js
@@ -111,6 +111,7 @@ export default function PopularPosts({ posts }) {
             frontmatter={post}
             image={false}
             key={post._meta?.filePath}
+            headingLevel={3}
             className="max-sm:w-[calc(100vw-48px)] max-sm:snap-center md:col-span-1"
           />
         ))}

--- a/content/blog/0058-svg-reusability-animation.md
+++ b/content/blog/0058-svg-reusability-animation.md
@@ -2,7 +2,7 @@
 title: 'SVG reusability & animation'
 date: '2015-01-27T08:00:00+00:00'
 lastmod: '2021-06-11T06:05:56+00:00'
-summary: ‘How to animate and reuse inline SVG with CSS. Using currentColor and groups you can change fills and animate paths, saving on page weight by avoiding multiple images.’
+summary: 'How to animate and reuse inline SVG with CSS. Using currentColor and groups you can change fills and animate paths, saving on page weight by avoiding multiple images.'
 metadesc: 'How to animate and change fill colours on inline SVG. Using currentcolor and groups we can animate and manipulate SVG unlike any other image type.'
 theme: '#ffede5'
 tags: ['Code']

--- a/content/blog/0059-overcoming-a-couple-of-issues-with-svg-filter-effects.md
+++ b/content/blog/0059-overcoming-a-couple-of-issues-with-svg-filter-effects.md
@@ -2,7 +2,7 @@
 title: 'Overcoming a couple of issues with SVG filter effects'
 date: '2015-02-03T08:00:00+00:00'
 lastmod: '2016-08-28T12:54:02+00:00'
-summary: ‘SVG filter effects are useful for illustration details on the web. This post covers two problems encountered using Gaussian blur — lower saturation in Safari and filter clipping.’
+summary: 'SVG filter effects are useful for illustration details on the web. This post covers two problems encountered using Gaussian blur — lower saturation in Safari and filter clipping.'
 metadesc: 'SVG filters are really useful for infinitely scalable effects but they come with some issues, such as appearing with lower saturation in Safari and filter clipping at certain sizes.'
 theme: '#fffbf2'
 tags: ['Code']

--- a/content/blog/0066-adobe-generator-syntax-cheatsheet.md
+++ b/content/blog/0066-adobe-generator-syntax-cheatsheet.md
@@ -2,7 +2,7 @@
 title: 'Adobe generator syntax ‘cheatsheet’'
 date: '2015-03-17T08:00:00+00:00'
 lastmod: '2018-06-01T08:49:16+00:00'
-summary: ‘A clear reference for Adobe Generator layer naming syntax, with examples for common use cases — the cheatsheet the Adobe docs never quite provided.’
+summary: 'A clear reference for Adobe Generator layer naming syntax, with examples for common use cases — the cheatsheet the Adobe docs never quite provided.'
 metadesc: 'A cheatsheet for Adobe’s generator syntax, with examples for common use cases.'
 theme: '#e1f7ee'
 tags: ['Design']

--- a/content/blog/0071-using-cookies-to-serve-critical-css-for-first-time-visits.md
+++ b/content/blog/0071-using-cookies-to-serve-critical-css-for-first-time-visits.md
@@ -2,7 +2,7 @@
 title: 'Using cookies to serve critical CSS for first time visits'
 date: '2015-04-21T06:45:00+00:00'
 lastmod: '2016-08-28T11:00:46+00:00'
-summary: ‘How to use cookies with critical path CSS so returning visitors load the full stylesheet instead. A follow-up to the critical CSS post, covering the caching side.’
+summary: 'How to use cookies with critical path CSS so returning visitors load the full stylesheet instead. A follow-up to the critical CSS post, covering the caching side.'
 metadesc: 'How to use cookies to cache your critical CSS. A simple approach involving making your CSS asynchronous, applying a cookie and checking for it.'
 theme: '#ffede5'
 tags: ['Code']

--- a/content/blog/0073-flexbox-quick-wins.md
+++ b/content/blog/0073-flexbox-quick-wins.md
@@ -2,7 +2,7 @@
 title: 'Flexbox quick wins'
 date: '2015-05-05T06:00:00+00:00'
 lastmod: '2016-08-28T11:00:20+00:00'
-summary: ‘A few flexbox techniques you can use today without worrying about older browser knock-on effects. Handy when you don’t have time for a full flexbox layout.’
+summary: 'A few flexbox techniques you can use today without worrying about older browser knock-on effects. Handy when you don’t have time for a full flexbox layout.'
 metadesc: 'Flexbox isn‘t quite ready to have layouts built dedicated with it. There are some uses with flexbox we can apply without worry of what will impact other browsers.'
 theme: '#e9f5f5'
 tags: ['Code']

--- a/content/blog/0086-redirecting-an-old-domain-to-a-new-domain-with-nginx.md
+++ b/content/blog/0086-redirecting-an-old-domain-to-a-new-domain-with-nginx.md
@@ -81,7 +81,7 @@ server {
 }
 ```
 
-The important things to note here: we're hardcoding `https://` rather than using `$scheme` so the redirect always lands on HTTPS regardless of how the request came in. And `$request_uri` preserves anything after the domain, so `/blog/some-post` on the old domain redirects to `/blog/some-post` on the new one. Your visitors and any existing links will end up in the right place.
+The important things to note here: we're hardcoding `https://` rather than using `$scheme` so the redirect always lands on HTTPS regardless of how the request came in. And `$request_uri` preserves anything after the domain, so a path like `/blog/<slug>` on the old domain ends up at the same path on the new one. Your visitors and any existing links will end up in the right place.
 
 Update any other instances of `server_name` throughout your config file that you may have.
 

--- a/content/blog/0087-a-guide-to-vertical-rhythm.md
+++ b/content/blog/0087-a-guide-to-vertical-rhythm.md
@@ -2,7 +2,7 @@
 title: 'A guide to vertical rhythm'
 date: '2015-08-11T06:41:00+00:00'
 lastmod: '2018-10-15T11:09:25+00:00'
-summary: ‘Vertical rhythm creates visual harmony between text and other elements on a page. This guide focuses on the why rather than the how, to build a solid understanding.’
+summary: 'Vertical rhythm creates visual harmony between text and other elements on a page. This guide focuses on the why rather than the how, to build a solid understanding.'
 metadesc: "If you've ever struggled with how vertical rhythm is achieved, I will guide you through how you choose a baseline, sizing and images."
 theme: '#fffbee'
 tags: ['Design']

--- a/content/blog/0089-accuracy-in-wireframes.md
+++ b/content/blog/0089-accuracy-in-wireframes.md
@@ -2,7 +2,7 @@
 title: 'Accuracy in wireframes'
 date: '2015-08-25T06:17:00+00:00'
 lastmod: '2016-08-28T10:54:41+00:00'
-summary: ‘Why wireframes should strip all visual style and focus purely on layout. Accurate wireframes make for a stronger foundation before adding visual design.’
+summary: 'Why wireframes should strip all visual style and focus purely on layout. Accurate wireframes make for a stronger foundation before adding visual design.'
 metadesc: 'My opinion on why wireframes should be completely accurate to the final design and how it can save you time and frustration.'
 theme: '#e9f5f5'
 tags: ['Design']

--- a/content/blog/0098-using-grunticon-to-inline-svg.md
+++ b/content/blog/0098-using-grunticon-to-inline-svg.md
@@ -2,7 +2,7 @@
 title: 'Using Grunticon to inline SVG'
 date: '2015-10-27T07:34:00+00:00'
 lastmod: '2016-08-28T10:49:57+00:00'
-summary: ‘Grunticon V2 added the ability to insert inline SVG, generating fallbacks for older browsers. Inline SVG is easily styled with CSS, all done via a Grunt task.’
+summary: 'Grunticon V2 added the ability to insert inline SVG, generating fallbacks for older browsers. Inline SVG is easily styled with CSS, all done via a Grunt task.'
 metadesc: 'Grunticon updated to V2 a while ago now and what came with it was the ability to insert inline SVG. This post covers how to use it effectively.'
 theme: '#e1f7ee'
 tags: ['Code']

--- a/content/blog/0100-tips-for-sketching-websites.md
+++ b/content/blog/0100-tips-for-sketching-websites.md
@@ -2,7 +2,7 @@
 title: 'Tips for sketching websites'
 date: '2015-11-10T07:29:00+00:00'
 lastmod: '2016-08-28T10:49:36+00:00'
-summary: ‘Sketching before wireframing is easy to skip, but you’re missing out if you do. This post walks through a process for sketching websites, even if you don’t think you can draw.’
+summary: 'Sketching before wireframing is easy to skip, but you’re missing out if you do. This post walks through a process for sketching websites, even if you don’t think you can draw.'
 metadesc: "I believe sketching should always be part of your process. It's the quickest method to iterate and ingrain ideas in our minds."
 theme: '#fffbf2'
 tags: ['Design']

--- a/content/blog/0105-colour-series-picking-your-palette.md
+++ b/content/blog/0105-colour-series-picking-your-palette.md
@@ -2,7 +2,7 @@
 title: 'Colour series: picking your palette'
 date: '2015-12-15T07:28:00+00:00'
 lastmod: '2018-03-07T13:17:26+00:00'
-summary: ‘Part one of the colour series. Colour theory is only a starting point — this post walks through what to actually consider when picking a 5-colour palette for a project.’
+summary: 'Part one of the colour series. Colour theory is only a starting point — this post walks through what to actually consider when picking a 5-colour palette for a project.'
 metadesc: 'How to choose an effective colour for your website project. From colours that represent your project to ones that help readability.'
 theme: '#f9f3f1'
 tags: ['Design']

--- a/content/blog/0109-horizontal-scrolling-toggle.md
+++ b/content/blog/0109-horizontal-scrolling-toggle.md
@@ -2,7 +2,7 @@
 title: 'Browse content efficiently with toggling horizontal scrolling'
 date: '2016-01-12T07:30:00+00:00'
 lastmod: '2021-06-17T06:24:00+00:00'
-summary: ‘A Finder-inspired pattern for toggling between horizontal and vertical scrolling layouts. Built with flexbox, making it easy to switch between compact and expanded views.’
+summary: 'A Finder-inspired pattern for toggling between horizontal and vertical scrolling layouts. Built with flexbox, making it easy to switch between compact and expanded views.'
 metadesc: 'Allow for the best of both worlds with horizontal scrolling and toggle to vertical layout. Using flexbox this makes layouts easy to adjust.'
 theme: '#e9f5f5'
 tags: ['Code']

--- a/content/blog/0112-how-to-flexible-squares-with-css.md
+++ b/content/blog/0112-how-to-flexible-squares-with-css.md
@@ -2,7 +2,7 @@
 title: 'How to: flexible squares with CSS'
 date: '2016-02-02T07:30:00+00:00'
 lastmod: '2018-01-28T20:21:51+00:00'
-summary: ‘How to maintain a perfect square in a responsive layout using CSS padding. A quick tip covering the technique and how to handle content within the square.’
+summary: 'How to maintain a perfect square in a responsive layout using CSS padding. A quick tip covering the technique and how to handle content within the square.'
 metadesc: "How do you maintain a perfect square shape with a responsive layout? It's a relatively simple solution using padding."
 theme: '#fffdf5'
 tags: ['Code', 'CSS']

--- a/content/blog/0120-hero-area-series-html-css-responsive.md
+++ b/content/blog/0120-hero-area-series-html-css-responsive.md
@@ -2,7 +2,7 @@
 title: 'Hero area series: HTML, CSS & responsive'
 date: '2016-04-05T06:30:00+00:00'
 lastmod: '2016-08-28T09:58:02+00:00'
-summary: ‘Coding the hero area using flexbox and making it responsive. A mostly mobile-first approach, applying CSS where it makes logical sense to avoid undoing it later.’
+summary: 'Coding the hero area using flexbox and making it responsive. A mostly mobile-first approach, applying CSS where it makes logical sense to avoid undoing it later.'
 metadesc: 'The second to last post in this series, coding the page. You’re going to build the page using flexbox and make it responsive.'
 theme: '#e9f5f5'
 tags: ['Design', 'Code']

--- a/content/blog/0129-why-you-should-use-tachyons-to-make-css-easier.md
+++ b/content/blog/0129-why-you-should-use-tachyons-to-make-css-easier.md
@@ -2,7 +2,7 @@
 title: 'Why you should use tachyons to make CSS easier'
 date: '2016-06-07T06:30:00+00:00'
 lastmod: '2016-08-28T09:17:19+00:00'
-summary: ‘The tachyons approach to CSS makes sense, particularly for spacing and font sizes. This post explains the benefits and how to adapt it to how you already write CSS.’
+summary: 'The tachyons approach to CSS makes sense, particularly for spacing and font sizes. This post explains the benefits and how to adapt it to how you already write CSS.'
 metadesc: 'Find out how tachyons can help speed up building a website, but most of all keep things expected and consistent.'
 theme: '#e1f7ee'
 tags: ['Code', 'CSS']

--- a/content/blog/0135-css-only-ios-style-toggle.md
+++ b/content/blog/0135-css-only-ios-style-toggle.md
@@ -2,7 +2,7 @@
 title: 'CSS only iOS style ‘toggle’'
 date: '2016-07-19T06:30:00+00:00'
 lastmod: '2016-08-28T09:14:48+00:00'
-summary: ‘A CSS-only iOS-style toggle using a hidden checkbox and the :checked pseudo class with the adjacent sibling selector. No JavaScript required.’
+summary: 'A CSS-only iOS-style toggle using a hidden checkbox and the :checked pseudo class with the adjacent sibling selector. No JavaScript required.'
 metadesc: 'No JavaScript required, iOS style toggle with CSS. Using the :checked pseudo class and adjacent sibling selector it makes it possible.'
 theme: '#e9f5f5'
 tags: ['Code']

--- a/content/blog/0136-designing-a-pricing-table-in-code.md
+++ b/content/blog/0136-designing-a-pricing-table-in-code.md
@@ -2,7 +2,7 @@
 title: 'Designing a pricing table in code'
 date: '2016-07-26T06:37:00+00:00'
 lastmod: '2016-08-28T09:14:08+00:00'
-summary: ‘Coding up the pricing table designed in Illustrator. Flexbox handles the layout, keeping focus on matching the design and adding interactive button states.’
+summary: 'Coding up the pricing table designed in Illustrator. Flexbox handles the layout, keeping focus on matching the design and adding interactive button states.'
 metadesc: 'Using flexbox to do the heavy lifting for the layout, the focus can be on matching the design and improving on it through being able to show the button state.'
 theme: '#e9f5f5'
 tags: ['Code']

--- a/content/blog/0140-illustrator-quick-tip-equally-space-objects.md
+++ b/content/blog/0140-illustrator-quick-tip-equally-space-objects.md
@@ -2,7 +2,7 @@
 title: 'How to evenly space objects in Illustrator'
 date: '2016-08-23T06:30:00+00:00'
 lastmod: '2018-09-13T18:56:32+00:00'
-summary: ‘How to distribute objects with equal spacing in Illustrator using align to key object. A quick tip that saves spacing things out one by one.’
+summary: 'How to distribute objects with equal spacing in Illustrator using align to key object. A quick tip that saves spacing things out one by one.'
 metadesc: 'The quickest way to add equal spacing between objects in Illustrator. Use align to key object to distribute space with a precise pixel value.'
 theme: '#fefbed'
 tags: ['Design']

--- a/content/blog/0172-the-best-ink-trap-typefaces-for-websites.md
+++ b/content/blog/0172-the-best-ink-trap-typefaces-for-websites.md
@@ -1,7 +1,7 @@
 ---
-title: 'The best ink trap fonts for web design'
+title: 'The best ink trap typefaces for websites'
 date: '2021-07-28T10:28:00+00:00'
-lastmod: '2026-04-20T18:21:44+00:00'
+lastmod: '2026-06-12T20:45:00+00:00'
 summary: 'A look at type that features prominent cuts or tapering into the type and a variety of recommendations you can use in your designs.'
 metadesc: 'A curated collection of ink trap typefaces for websites, including free Google Fonts options and premium picks from foundries like OH no Type Co and Pangram Pangram.'
 theme: '#f9f3f1'

--- a/content/blog/0173-about-version-7/index.md
+++ b/content/blog/0173-about-version-7/index.md
@@ -66,7 +66,7 @@ Thankfully one was far easier than the others.
 
 One of the things I felt ~~could~~ would be a problem was the current URL structure surrounding blog posts. And I didn’t want to have that as a problem on top of moving to Next.js and a new hosting platform.
 
-The structure was `/blog/entry/[slug]` and was moving to `/blog/[slug]`.
+The structure was `/blog/entry/<slug>` and was moving to `/blog/<slug>`.
 
 I was aware this would break links from other websites, for which I setup redirects. And knew by the time I’d finally finish redeveloping the website on Next all the issues will have been ironed out.
 

--- a/content/blog/0175-bento-layout-css-grid.md
+++ b/content/blog/0175-bento-layout-css-grid.md
@@ -1,7 +1,7 @@
 ---
-title: Build a bento grid layout with CSS
+title: Bento grid layout with CSS grid and container queries
 date: '2024-07-02T14:58:09.706Z'
-lastmod: '2026-04-20T17:48:51.000Z'
+lastmod: '2026-06-12T20:45:00.000Z'
 summary: Bento grids offer a unique layout challenge for CSS. With the use of Tailwind you can create a flexible layout with modern CSS grid and @container queries.
 metadesc: Build a responsive bento grid using CSS grid, container queries and Tailwind. Includes a Figma design file and complete code on GitHub.
 theme: '#fcf9f8'

--- a/content/collections/betterbydesign.md
+++ b/content/collections/betterbydesign.md
@@ -1,7 +1,7 @@
 ---
-title: Better by Design | Patrick Morgan | Substack
-url: "https://www.betterbydesign.cc/"
-date: "2025-03-13T21:05:39.299Z"
+title: Better by Design
+url: 'https://www.betterbydesign.cc/'
+date: '2025-03-13T21:05:39.299Z'
 collection:
   - Publication
 type: Collections

--- a/content/collections/bpando.md
+++ b/content/collections/bpando.md
@@ -1,7 +1,7 @@
 ---
-title: BP&O - Branding, Packaging and Opinion
-url: "https://bpando.org/"
-date: "2025-03-13T21:05:39.300Z"
+title: 'BP&O'
+url: 'https://bpando.org/'
+date: '2025-03-13T21:05:39.300Z'
 collection:
   - Publication
 type: Collections

--- a/content/collections/brandingwebsite.md
+++ b/content/collections/brandingwebsite.md
@@ -1,7 +1,7 @@
 ---
-title: Branding Website · Featuring the Best Branding Websites on the Internet
-url: "https://www.brandingwebsite.com/"
-date: "2025-03-13T21:05:39.294Z"
+title: Branding Website
+url: 'https://www.brandingwebsite.com/'
+date: '2025-03-13T21:05:39.294Z'
 collection:
   - Inspiration
 type: Collections

--- a/content/collections/brownjuice-study.md
+++ b/content/collections/brownjuice-study.md
@@ -1,7 +1,7 @@
 ---
-title: Design Externship
+title: UX smells
 url: https://brownjuice.co/study/?article=a3
-date: "2025-12-06T18:47:01.793Z"
+date: '2025-12-06T18:47:01.793Z'
 collection:
   - ux-design
 type: Collections

--- a/content/collections/c82-iconography.md
+++ b/content/collections/c82-iconography.md
@@ -1,7 +1,7 @@
 ---
-title: iconographic-encyclopaedia
-url: "https://www.c82.net/iconography/"
-date: "2025-03-13T21:05:39.296Z"
+title: Iconographic encyclopaedia
+url: 'https://www.c82.net/iconography/'
+date: '2025-03-13T21:05:39.296Z'
 collection:
   - misc
 type: Collections

--- a/content/collections/commercecream.md
+++ b/content/collections/commercecream.md
@@ -1,8 +1,0 @@
----
-title: Commerce Cream
-url: https://commercecream.com
-date: 2024-03-22
-collection:
-  - Inspiration
-type: Collections
----

--- a/content/collections/deadsimplesites.md
+++ b/content/collections/deadsimplesites.md
@@ -1,7 +1,7 @@
 ---
-title: Dead Simple Sites — Minimal Website Inspiration
-url: "https://deadsimplesites.com/"
-date: "2025-03-13T21:05:39.294Z"
+title: Dead Simple Sites
+url: 'https://deadsimplesites.com/'
+date: '2025-03-13T21:05:39.294Z'
 collection:
   - Inspiration
 type: Collections

--- a/content/collections/deck.md
+++ b/content/collections/deck.md
@@ -1,7 +1,7 @@
 ---
-title: Deck.Gallery® — Beautifully designed decks, curated
-url: "https://www.deck.gallery/"
-date: "2025-03-13T21:05:39.296Z"
+title: Deck.Gallery
+url: 'https://www.deck.gallery/'
+date: '2025-03-13T21:05:39.296Z'
 collection:
   - misc
 type: Collections

--- a/content/collections/drgurner-substack.md
+++ b/content/collections/drgurner-substack.md
@@ -1,7 +1,7 @@
 ---
-title: Ultra Successful | Dr. Julie Gurner | Substack
-url: "https://drgurner.substack.com/"
-date: "2025-03-13T21:05:39.299Z"
+title: Ultra Successful
+url: 'https://drgurner.substack.com/'
+date: '2025-03-13T21:05:39.299Z'
 collection:
   - Publication
 type: Collections

--- a/content/collections/kubie-blog-the-most-useful-articles-about-ux-content-and-design.md
+++ b/content/collections/kubie-blog-the-most-useful-articles-about-ux-content-and-design.md
@@ -1,7 +1,7 @@
 ---
-title: The Most Useful UX and Content Design Articles - kubie.co
-url: "https://kubie.co/blog/the-most-useful-articles-about-ux-content-and-design/"
-date: "2025-03-13T21:05:39.294Z"
+title: The most useful UX and content design articles
+url: 'https://kubie.co/blog/the-most-useful-articles-about-ux-content-and-design/'
+date: '2025-03-13T21:05:39.294Z'
 collection:
   - ux-design
 type: Collections

--- a/content/collections/logo-archive.md
+++ b/content/collections/logo-archive.md
@@ -1,7 +1,7 @@
 ---
-title: LogoArchive • Logo inspiration and historical archive
-url: "https://www.logo-archive.org/"
-date: "2025-03-13T21:05:39.296Z"
+title: LogoArchive
+url: 'https://www.logo-archive.org/'
+date: '2025-03-13T21:05:39.296Z'
 collection:
   - brand
 type: Collections

--- a/content/collections/medium-jinsoncjohny-color-formula-a-practical-framework-for-ui-designers-and-developers-working-with.md
+++ b/content/collections/medium-jinsoncjohny-color-formula-a-practical-framework-for-ui-designers-and-developers-working-with.md
@@ -1,7 +1,7 @@
 ---
-title: "Color Formula: A Practical Framework for UI Designers and Developers Working with Dynamic Colors"
+title: 'Color formula: a practical framework for UI designers and developers working with dynamic colors'
 url: https://medium.com/@jinsoncjohny/color-formula-a-practical-framework-for-ui-designers-and-developers-working-with-dynamic-colors-f1e6b2ef41d2
-date: "2025-12-06T18:47:01.794Z"
+date: '2025-12-06T18:47:01.794Z'
 collection:
   - Colour
 type: Collections

--- a/content/collections/news-arcade.md
+++ b/content/collections/news-arcade.md
@@ -1,7 +1,7 @@
 ---
-title: HI-FIVE | Arcade Labs | Substack
-url: "https://news.arcade.la/"
-date: "2025-03-13T21:05:39.298Z"
+title: HI-FIVE
+url: 'https://news.arcade.la/'
+date: '2025-03-13T21:05:39.298Z'
 collection:
   - Publication
 type: Collections

--- a/content/collections/snackablecopytips.md
+++ b/content/collections/snackablecopytips.md
@@ -1,8 +1,0 @@
----
-title: Snackable Copy Tips
-url: "https://www.snackablecopytips.com/"
-date: "2025-03-13T21:05:39.294Z"
-collection:
-  - Content
-type: Collections
----

--- a/content/collections/ta11y-learning.md
+++ b/content/collections/ta11y-learning.md
@@ -1,7 +1,7 @@
 ---
-title: Learn about Accessibility | ta11y
-url: "https://www.ta11y.org/learning"
-date: "2025-03-13T21:05:39.292Z"
+title: Learn about accessibility
+url: 'https://www.ta11y.org/en/learning'
+date: '2025-03-13T21:05:39.292Z'
 collection:
   - Accessibility
 type: Collections

--- a/content/collections/the-brandidentity.md
+++ b/content/collections/the-brandidentity.md
@@ -1,7 +1,7 @@
 ---
-title: The Brand Identity – Graphic Design’s Greatest
-url: "https://the-brandidentity.com/"
-date: "2025-03-13T21:05:39.298Z"
+title: The Brand Identity
+url: 'https://the-brandidentity.com/'
+date: '2025-03-13T21:05:39.298Z'
 collection:
   - Publication
 type: Collections

--- a/content/collections/visualjournal.md
+++ b/content/collections/visualjournal.md
@@ -1,7 +1,7 @@
 ---
-title: Visual Journal – Branding, Editorial and Graphic Design
-url: "https://visualjournal.it/"
-date: "2025-03-13T21:05:39.296Z"
+title: Visual Journal
+url: 'https://visualjournal.it/'
+date: '2025-03-13T21:05:39.296Z'
 collection:
   - brand
 type: Collections

--- a/lib/agent/errors.js
+++ b/lib/agent/errors.js
@@ -1,0 +1,39 @@
+import { NextResponse } from 'next/server'
+
+import siteMetadata from '@/content/metadata'
+
+/**
+ * Every API error uses one shape so an agent can branch on `error.code`
+ * without parsing prose, and `error.hint` tells it what to do next.
+ *
+ * {
+ *   "error": {
+ *     "code": "EMAIL_REQUIRED",
+ *     "message": "An email address is required.",
+ *     "hint": "Send a JSON body with an \"email\" field.",
+ *     "status": 400,
+ *     "documentation": "https://iamsteve.me/openapi.json"
+ *   }
+ * }
+ */
+export function apiError({ status, code, message, hint, headers }) {
+  return NextResponse.json(
+    {
+      error: {
+        code,
+        message,
+        hint,
+        status,
+        documentation: `${siteMetadata.siteUrl}/openapi.json`,
+      },
+    },
+    {
+      status,
+      headers: {
+        'Content-Type': 'application/json; charset=utf-8',
+        'Cache-Control': 'no-store',
+        ...headers,
+      },
+    }
+  )
+}

--- a/lib/agent/markdown.js
+++ b/lib/agent/markdown.js
@@ -1,0 +1,30 @@
+import siteMetadata from '@/content/metadata'
+
+import { notFoundMarkdown } from './not-found'
+
+/**
+ * `Vary: Accept` is what stops a shared cache handing the HTML variant to an
+ * agent that asked for markdown, or the other way round.
+ */
+export const MARKDOWN_VARY = 'Accept, Accept-Encoding'
+
+export const markdownHeaders = {
+  'Content-Type': 'text/markdown; charset=utf-8',
+  'Cache-Control': 'public, max-age=86400, s-maxage=86400',
+  Vary: MARKDOWN_VARY,
+}
+
+/**
+ * A 404 an agent can act on: the same recovery links the HTML 404 page shows,
+ * served as markdown. `pathname` is the public URL that was asked for.
+ */
+export function markdownNotFound(pathname) {
+  return new Response(notFoundMarkdown(siteMetadata.siteUrl, pathname), {
+    status: 404,
+    headers: {
+      'Content-Type': 'text/markdown; charset=utf-8',
+      'Cache-Control': 'no-store',
+      Vary: MARKDOWN_VARY,
+    },
+  })
+}

--- a/lib/agent/not-found.js
+++ b/lib/agent/not-found.js
@@ -1,0 +1,93 @@
+/**
+ * Recovery pointers served with every 404 and 410, so an agent that lands on a
+ * dead URL can find its way back without guessing. Shared by the HTML
+ * not-found page, the markdown 404s, and the proxy.
+ *
+ * Kept free of Node built-ins and framework imports because `proxy.js` runs
+ * this on the edge runtime.
+ */
+export const recoveryLinks = [
+  { href: '/', title: 'Homepage', description: 'Latest and popular articles' },
+  {
+    href: '/blog',
+    title: 'Blog archive',
+    description: 'Every published article',
+  },
+  { href: '/notes', title: 'Notes', description: 'Shorter, in-progress posts' },
+  {
+    href: '/sitemap.xml',
+    title: 'Sitemap',
+    description: 'Every indexable URL on the site',
+  },
+  {
+    href: '/llms.txt',
+    title: 'llms.txt',
+    description: 'Curated index of the best articles, with markdown links',
+  },
+  {
+    href: '/openapi.json',
+    title: 'OpenAPI description',
+    description: 'The public API surface, machine readable',
+  },
+  {
+    href: '/.well-known/api-catalog',
+    title: 'API catalog',
+    description: 'RFC 9727 catalog of the APIs this site offers',
+  },
+]
+
+function recoveryMarkdown(origin, pathname, status, heading, opening) {
+  const links = recoveryLinks
+    .map(
+      (link) => `- [${link.title}](${origin}${link.href}): ${link.description}`
+    )
+    .join('\n')
+
+  return `---
+title: "${heading}"
+status: ${status}
+url: ${origin}${pathname}
+---
+
+# ${heading}
+
+${opening}
+
+## Where to look next
+
+${links}
+
+## Markdown representations
+
+Blog posts, notes, pages and collection entries are available as markdown two
+ways. Request the HTML URL with an \`Accept: text/markdown\` header, or append
+\`.md\` to it.
+
+- \`${origin}/api/content/{slug}\` for a blog article
+- \`${origin}/api/content/notes/{slug}\` for a note
+- \`${origin}/api/content/pages/{slug}\` for a standalone page
+- \`${origin}/api/content/collections/{slug}\` for a collection listing
+`
+}
+
+/** A 404 an agent can act on, as markdown. */
+export function notFoundMarkdown(origin, pathname) {
+  return recoveryMarkdown(
+    origin,
+    pathname,
+    404,
+    '404 Not Found',
+    `There is no content at \`${pathname}\` on iamsteve.me.`
+  )
+}
+
+/** A 410 an agent can act on. Stop asking for this URL, try these instead. */
+export function goneMarkdown(origin, pathname) {
+  return recoveryMarkdown(
+    origin,
+    pathname,
+    410,
+    '410 Gone',
+    `\`${pathname}\` has been permanently removed from iamsteve.me and will not come back. Do not retry it.`
+  )
+}

--- a/lib/compile-mdx-for-rss.js
+++ b/lib/compile-mdx-for-rss.js
@@ -7,12 +7,24 @@
 
 import { rssComponents } from './rss-components.js'
 import { marked } from 'marked'
+import siteMetadata from '../content/metadata.js'
 
 // Configure marked to not escape HTML entities
 marked.setOptions({
   mangle: false,
   headerIds: false,
 })
+
+/**
+ * Rewrite root-relative hrefs and srcs to absolute URLs. Feed readers show the
+ * markup outside the site, so they have no base URL to resolve against.
+ */
+function absoluteUrls(html) {
+  return html.replace(
+    /(href|src)="(\/(?!\/)[^"]*)"/g,
+    `$1="${siteMetadata.siteUrl}$2"`
+  )
+}
 
 /**
  * Simple JSX component parser and replacer
@@ -231,5 +243,5 @@ export function compileMdxForRssWithMarked(mdxContent) {
   } while (content !== prev)
 
   // Then use marked to convert markdown to HTML
-  return marked(content)
+  return absoluteUrls(marked(content))
 }

--- a/lib/utils/clean-markdown-for-llms.js
+++ b/lib/utils/clean-markdown-for-llms.js
@@ -1,3 +1,13 @@
+import siteMetadata from '@/content/metadata'
+
+/**
+ * Rewrite root-relative markdown links and images to absolute URLs. The
+ * markdown is served standalone, so there is no document to resolve against.
+ */
+function absoluteLinks(text) {
+  return text.replace(/\]\((\/(?!\/)[^)]*)\)/g, `](${siteMetadata.siteUrl}$1)`)
+}
+
 /**
  * Clean markdown for LLM consumption by removing custom React components
  * and converting them to simple markdown equivalents
@@ -67,7 +77,7 @@ export function cleanMarkdownForLLMs(markdown) {
           caption = caption.replace(/<p>/g, '').replace(/<\/p>/g, '')
           // Transform <Fig>N</Fig> to **Figure N**
           caption = caption.replace(/<Fig>(\d+)<\/Fig>/g, '**Figure $1**')
-          figcaption = caption.trim()
+          figcaption = absoluteLinks(caption.trim())
         }
       }
       continue
@@ -104,6 +114,8 @@ export function cleanMarkdownForLLMs(markdown) {
       /<Demo\s+src="([^"]+)"\s*\/>/g,
       '[View interactive demo]($1)'
     )
+
+    line = absoluteLinks(line)
 
     // Remove <Image> tags entirely (single line)
     line = line.replace(/<Image\s+[^>]*\/>/g, '')

--- a/link-check-ignore.json
+++ b/link-check-ignore.json
@@ -1,0 +1,4 @@
+{
+  "_readme": "Links you have checked by hand and want the validator to leave alone. Add an entry to \"urls\" as \"the-url\": \"why it is fine\" — the reason is a note to yourself, the script only reads the key. Matching ignores protocol, www, trailing slash, fragments and tracking params, so https://www.example.com/ and https://example.com match the same entry. Example: \"https://example.com\": \"Cloudflare refuses CI runners, opened it manually 2026-08-01\".",
+  "urls": {}
+}

--- a/link-check-ignore.json
+++ b/link-check-ignore.json
@@ -1,4 +1,7 @@
 {
   "_readme": "Links you have checked by hand and want the validator to leave alone. Add an entry to \"urls\" as \"the-url\": \"why it is fine\" — the reason is a note to yourself, the script only reads the key. Matching ignores protocol, www, trailing slash, fragments and tracking params, so https://www.example.com/ and https://example.com match the same entry. Example: \"https://example.com\": \"Cloudflare refuses CI runners, opened it manually 2026-08-01\".",
-  "urls": {}
+  "urls": {
+    "https://brownjuice.co/study/?article=a3": "UX smells. Refuses automated requests with a 403, opened by hand 2026-08-01 and fine",
+    "https://www.c82.net/iconography/": "Iconographic encyclopaedia. Refuses automated requests with a 403, opened by hand 2026-08-01 and fine"
+  }
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -23,6 +23,40 @@
     [context.production.headers.values]
       Cache-Control = "public, max-age=0, s-maxage=3600, stale-while-revalidate=60"
 
+# Markdown content negotiation. Next.js overwrites `Vary` on every page
+# response with its own RSC token list, so `Accept` has to be added here or a
+# CDN can hand the cached HTML to an agent that asked for markdown. The RSC
+# tokens are repeated so replacing the header loses nothing.
+  [[context.production.headers]]
+    for = "/"
+    [context.production.headers.values]
+      Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+
+  [[context.production.headers]]
+    for = "/blog/*"
+    [context.production.headers.values]
+      Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+
+  [[context.production.headers]]
+    for = "/notes/*"
+    [context.production.headers.values]
+      Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+
+  [[context.production.headers]]
+    for = "/collections/*"
+    [context.production.headers.values]
+      Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+
+  [[context.production.headers]]
+    for = "/about"
+    [context.production.headers.values]
+      Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+
+  [[context.production.headers]]
+    for = "/uses"
+    [context.production.headers.values]
+      Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+
 # Development context (includes deploy previews and branch deploys)
 # X-Robots-Tag keeps non-production deploys out of Google's index while
 # leaving them crawlable, so the noindex is actually seen
@@ -49,6 +83,37 @@
   for = "/feed.xml"
   [headers.values]
     Cache-Control = "public, s-maxage=3600, stale-while-revalidate=60"
+
+# Markdown content negotiation, see the note in the production context above.
+[[headers]]
+  for = "/"
+  [headers.values]
+    Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+
+[[headers]]
+  for = "/blog/*"
+  [headers.values]
+    Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+
+[[headers]]
+  for = "/notes/*"
+  [headers.values]
+    Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+
+[[headers]]
+  for = "/collections/*"
+  [headers.values]
+    Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+
+[[headers]]
+  for = "/about"
+  [headers.values]
+    Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+
+[[headers]]
+  for = "/uses"
+  [headers.values]
+    Vary = "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
 
 [[redirects]]
   from = "/blog/entry/horizontal‑scrolling‑responsive‑menu"

--- a/netlify.toml
+++ b/netlify.toml
@@ -24,17 +24,21 @@
       Cache-Control = "public, max-age=0, s-maxage=3600, stale-while-revalidate=60"
 
 # Development context (includes deploy previews and branch deploys)
+# X-Robots-Tag keeps non-production deploys out of Google's index while
+# leaving them crawlable, so the noindex is actually seen
 [context.deploy-preview]
   [[context.deploy-preview.headers]]
     for = "/*"
     [context.deploy-preview.headers.values]
       Cache-Control = "public, max-age=0, must-revalidate"
+      X-Robots-Tag = "noindex"
 
 [context.branch-deploy]
   [[context.branch-deploy.headers]]
     for = "/*"
     [context.branch-deploy.headers.values]
       Cache-Control = "public, max-age=0, must-revalidate"
+      X-Robots-Tag = "noindex"
 
 [[headers]]
   for = "/*"

--- a/next.config.js
+++ b/next.config.js
@@ -195,6 +195,11 @@ const nextConfig = {
         permanent: true,
       },
       {
+        source: '/blog/entry/:slug(horizontal-scrolling-responsive-menu.*)',
+        destination: '/blog/horizontal-scrolling-responsive-menu',
+        permanent: true,
+      },
+      {
         source: '/blog/about_version_six',
         destination: '/blog/about-version-six',
         permanent: true,
@@ -311,11 +316,6 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/portfolio',
-        destination: '/about',
-        permanent: true,
-      },
-      {
         source: '/blog/\\{site_url\\}',
         destination: '/blog',
         permanent: true,
@@ -326,18 +326,8 @@ const nextConfig = {
         permanent: true,
       },
       {
-        source: '/mo',
-        destination: '/',
-        permanent: true,
-      },
-      {
         source: '/blog/entry/sass_hints_tips',
         destination: '/blog/sass-hints-and-tips',
-        permanent: true,
-      },
-      {
-        source: '/2',
-        destination: '/',
         permanent: true,
       },
       {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "date-fns": "^2.30.0",
     "dedent": "^0.7.0",
     "encoding": "^0.1.13",
-    "esbuild": "^0.25.0",
+    "esbuild": "^0.28.1",
     "eslint-config-next": "^16.2.0",
     "feed": "^4.2.2",
     "github-slugger": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "marked": "^14.1.4",
     "mdast-util-to-string": "^4.0.0",
     "motion": "^12.23.25",
-    "next": "^16.2.0",
+    "next": "^16.2.6",
     "postcss": "^8.5.10",
     "postcss-nesting": "^12.1.5",
     "radix-ui": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "marked": "^14.1.4",
     "mdast-util-to-string": "^4.0.0",
     "motion": "^12.23.25",
-    "next": "^16.2.6",
+    "next": "^16.2.11",
     "postcss": "^8.5.10",
     "postcss-nesting": "^12.1.5",
     "radix-ui": "^1.4.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "build": "pnpm lint && next build",
     "validate:links": "node scripts/validate-collection-links.js",
     "validate:links:all": "CHECK_ALL=true node scripts/validate-collection-links.js",
-    "prepare": "husky"
+    "prepare": "husky",
+    "test": "node --no-warnings --import ./tests/register.mjs --test \"tests/*.test.js\"",
+    "verify:agents": "node scripts/verify-agent-endpoints.js"
   },
   "browserslist": [
     "> 2%",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "remark-rehype": "^10.1.0",
     "remark-smartypants": "^2.1.0",
     "shiki": "^4.0.0",
-    "sharp": "^0.32.6",
+    "sharp": "^0.35.0",
     "swr": "^1.3.0",
     "tailwind-merge": "^3.4.0",
     "unified": "^11.0.5",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mdast-util-to-string": "^4.0.0",
     "motion": "^12.23.25",
     "next": "^16.2.11",
-    "postcss": "^8.5.10",
+    "postcss": "^8.5.18",
     "postcss-nesting": "^12.1.5",
     "radix-ui": "^1.4.3",
     "react": "19.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,8 +72,8 @@ importers:
         specifier: ^0.1.13
         version: 0.1.13
       esbuild:
-        specifier: ^0.25.0
-        version: 0.25.12
+        specifier: ^0.28.1
+        version: 0.28.1
       eslint-config-next:
         specifier: ^16.2.0
         version: 16.2.1(@typescript-eslint/parser@8.57.2(eslint@9.39.1(jiti@2.6.1))(typescript@5.7.2))(eslint@9.39.1(jiti@2.6.1))(typescript@5.7.2)
@@ -410,8 +410,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.1':
+    resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.1':
+    resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -422,8 +434,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.1':
+    resolution: {integrity: sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.1':
+    resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -434,8 +458,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.1':
+    resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.1':
+    resolution: {integrity: sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -446,8 +482,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.1':
+    resolution: {integrity: sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -458,8 +506,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.1':
+    resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.1':
+    resolution: {integrity: sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -470,8 +530,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.1':
+    resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.1':
+    resolution: {integrity: sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -482,8 +554,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.1':
+    resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.1':
+    resolution: {integrity: sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -494,8 +578,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.1':
+    resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.1':
+    resolution: {integrity: sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -506,8 +602,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.1':
+    resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -518,8 +626,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.1':
+    resolution: {integrity: sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.1':
+    resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -530,8 +650,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.1':
+    resolution: {integrity: sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.1':
+    resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -542,8 +674,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.1':
+    resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.1':
+    resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -554,8 +698,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.1':
+    resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.1':
+    resolution: {integrity: sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -2659,6 +2815,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -3281,6 +3438,11 @@ packages:
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.1:
+    resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -5755,79 +5917,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.1':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.28.1':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.28.1':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.1':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.1':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.1':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.1':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.28.1':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.1':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.1':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1(jiti@2.6.1))':
@@ -9026,6 +9266,35 @@ snapshots:
       '@esbuild/win32-arm64': 0.25.12
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
+
+  esbuild@0.28.1:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.1
+      '@esbuild/android-arm': 0.28.1
+      '@esbuild/android-arm64': 0.28.1
+      '@esbuild/android-x64': 0.28.1
+      '@esbuild/darwin-arm64': 0.28.1
+      '@esbuild/darwin-x64': 0.28.1
+      '@esbuild/freebsd-arm64': 0.28.1
+      '@esbuild/freebsd-x64': 0.28.1
+      '@esbuild/linux-arm': 0.28.1
+      '@esbuild/linux-arm64': 0.28.1
+      '@esbuild/linux-ia32': 0.28.1
+      '@esbuild/linux-loong64': 0.28.1
+      '@esbuild/linux-mips64el': 0.28.1
+      '@esbuild/linux-ppc64': 0.28.1
+      '@esbuild/linux-riscv64': 0.28.1
+      '@esbuild/linux-s390x': 0.28.1
+      '@esbuild/linux-x64': 0.28.1
+      '@esbuild/netbsd-arm64': 0.28.1
+      '@esbuild/netbsd-x64': 0.28.1
+      '@esbuild/openbsd-arm64': 0.28.1
+      '@esbuild/openbsd-x64': 0.28.1
+      '@esbuild/openharmony-arm64': 0.28.1
+      '@esbuild/sunos-x64': 0.28.1
+      '@esbuild/win32-arm64': 0.28.1
+      '@esbuild/win32-ia32': 0.28.1
+      '@esbuild/win32-x64': 0.28.1
 
   escalade@3.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
         specifier: ^2.1.0
         version: 2.1.0
       sharp:
-        specifier: ^0.32.6
-        version: 0.32.6
+        specifier: ^0.35.0
+        version: 0.35.0
       shiki:
         specifier: ^4.0.0
         version: 4.0.2
@@ -828,14 +828,36 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@img/sharp-darwin-arm64@0.35.0':
+    resolution: {integrity: sha512-ZgaYEwaj+lx/5n4W8GmZ2IYz0PQHjN5eqRcfijWGB+2Aq7ZInZGa0qJyAn6DEtyLuWHRSrmWOqT9q3qqTBvmUQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@img/sharp-darwin-x64@0.34.5':
     resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-darwin-x64@0.35.0':
+    resolution: {integrity: sha512-c1z9LFpKB0slQW3RchwBE8iSVzGp70TNjUUO9k4BZwwW4HH7JBGHeIy4b+kk4n/kcBASb9evKCE3/7Slmslgiw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-freebsd-wasm32@0.35.0':
+    resolution: {integrity: sha512-Li2KTev0H90kEtnJHkI9xQojXt1AqWmFBMXiPw5kqd1jQgP7gi5HVK/qC5Rmh/59NuAwUuPzzPITmX22NomYYQ==}
+    engines: {node: '>=20.9.0'}
+    os: [freebsd]
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
     resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.3.0':
+    resolution: {integrity: sha512-EKbmBKtyTH+GPFDRw2TgK2oV6hyxxlJVIar4hoTYSNmIwipgMFdxPQqR392GmfdsPGWga0mCFN1cCKjRb9cljw==}
     cpu: [arm64]
     os: [darwin]
 
@@ -844,8 +866,19 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@img/sharp-libvips-darwin-x64@1.3.0':
+    resolution: {integrity: sha512-Pl2OmOvrJ42adUllESxBsG54PfXLo1OYg9i3c5/5Ln/qJ0gZuTM9YMhQJPIbXqwidLRc/c2zuHt4RsrymmNv7A==}
+    cpu: [x64]
+    os: [darwin]
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm64@1.3.0':
+    resolution: {integrity: sha512-C0SqjoFKnszqa44EQ7xoaT48nnO0lOyXEULfXMWi8krrjOPGYkeK30Okzla6ATbBYsyZ0ySinK0FVkpv3DwzfQ==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
@@ -856,8 +889,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-arm@1.3.0':
+    resolution: {integrity: sha512-A8UpHoUDW4DwnXoV6+q3C1s7QLRAHtPDEjWuNZjwHMyoCNZnm0GeNN8ls9f/bsEYTRQRW96C/n34XJQHJ2fT7A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.3.0':
+    resolution: {integrity: sha512-WOpkVxAjFd369iaIzEgNRreFD+gWdUMIGD5zplhNKNeqS6mm5dac3q2AFyCBmzYoAdouzZvRBgxy4z8QHZb4/A==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
@@ -868,8 +913,20 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-riscv64@1.3.0':
+    resolution: {integrity: sha512-DRWw0mOHusrCCuw2rqP87oLg6PGlkomVDFqw2hIwsSfwWpu4k3XLcBPaKKl6ct/GtL/cwNkgwjV/tc0Mqht3VA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.3.0':
+    resolution: {integrity: sha512-9APy+nFWhHS+kzLgWZfLcyrUd7YqnAQVa4BPOo4xkoHpdoktOAPG4cEr9+Jpl0TtqfVmcMJimNL5qNTyyOHZNA==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
@@ -880,14 +937,32 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-libvips-linux-x64@1.3.0':
+    resolution: {integrity: sha512-y9RNUYDe2A1UAdhLyfeOodGRszQdaEoe4nfOpp/sNVPl2CWIcUyFaDoCh4vPLPxu19803j2naLqZup2WxDXCLA==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.0':
+    resolution: {integrity: sha512-cC1wkC0Mlucd0KSiGrLkJnB/ZqPvZCntc/Lk7ZnYO5ZSbF2euNek4Xvxafojq+wN1q/W0eprdpUIjUr/EV2PBg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.0':
+    resolution: {integrity: sha512-LiYMhUZicB1QG//+RvmYZpXJO8fYRENfp+MZUCnG9aw+AKvGAy9gPaCnuwsPcBFs8EV66M0NNxj9VHcNklE8zw==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -899,9 +974,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-arm64@0.35.0':
+    resolution: {integrity: sha512-4+4XHLNT5wDT0roYlHTEmH9lDKt0acf9Tv+3hM3iceOirkxrR404/3WjAYZ9F9CkHrxeRcGLJXbi4vluMZ9O+A==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.35.0':
+    resolution: {integrity: sha512-VVlpEWwizEFIOom0zdoeKuO5nuTswzVE5uHcBNvHzmeHUpNFajY3HFfbQ+zIH4E2kVaZ/yVxmsShW56TtEy4uA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
@@ -913,9 +1002,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-ppc64@0.35.0':
+    resolution: {integrity: sha512-N3hzbEpUTJC8pWpPVJvgzGxM+so/MAXc8O2s/53B0LL9ZGpfXpME7Wizkc5d/8fRBlBtkDjzoZGDCqqNDHqLEw==}
+    engines: {node: '>=20.9.0'}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.35.0':
+    resolution: {integrity: sha512-l6vmKVPnbS0RhVMbyxP5meAARsbhCnBN4fy31qz0+3a6Rv4jEqfzDrT89y6ZPkCi0AJGnwp2En528yXo401Hpw==}
+    engines: {node: '>=20.9.0'}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
@@ -927,9 +1030,23 @@ packages:
     os: [linux]
     libc: [glibc]
 
+  '@img/sharp-linux-s390x@0.35.0':
+    resolution: {integrity: sha512-MYlMiPFiv/EKPAHnp3yNZ9AAWFsxga9c5Bkc6wkar6bqzHLlkGVJHRm0u1ei+VXnZxp3Mz9MG9ZIsI8vSOf3sQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.35.0':
+    resolution: {integrity: sha512-TYaItB5oj1ioXjhyn2xrR208vf+YuIIcHptQWRRaBmFhvIvL9D72DXN8w75xup0KXA8UdEAhQ9Qb2S49FD/9Cw==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
@@ -941,9 +1058,23 @@ packages:
     os: [linux]
     libc: [musl]
 
+  '@img/sharp-linuxmusl-arm64@0.35.0':
+    resolution: {integrity: sha512-DSTb6ijQzqe6DdAaOBVqJ/SYf1vO8EW5bK6X6LRXufEBebf2722VCdvBUtZ3rtV0x2ApfPNDy/p7LrrjaWjiyQ==}
+    engines: {node: '>=20.9.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.35.0':
+    resolution: {integrity: sha512-K7ykQ+26Rt6+4BTU80AuGgTPIYX86UxiAKT4rcXX/WNTo7k1ZxpKz+TguHnwVpCqQK3B5PK0vZ0ZBe6nz/ib1w==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
@@ -953,9 +1084,24 @@ packages:
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [wasm32]
 
+  '@img/sharp-wasm32@0.35.0':
+    resolution: {integrity: sha512-9woLIFORERCr+6cWu87dQ22J34EExkhc73U1kZW0c+RclQqWetoodByp4dWZ/hN8/KVmTRAx2HOnUwib8AwZdA==}
+    engines: {node: '>=20.9.0'}
+
+  '@img/sharp-webcontainers-wasm32@0.35.0':
+    resolution: {integrity: sha512-t+kie1TOyaDM6Dho+f+y0VqIUNhYQaKCUahuZVi0E0frgdiaOaPsDxDW3wfKacUdaNBCnK/ZDBMg33ydvHj8uA==}
+    engines: {node: '>=20.9.0'}
+    cpu: [wasm32]
+
   '@img/sharp-win32-arm64@0.34.5':
     resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-arm64@0.35.0':
+    resolution: {integrity: sha512-M5eKxug0dabbaWgFKvPa3odNs2OpaP+81NASfGKkt4GcYXpNhSu7CaeYxWkLNV6vHmUp4hnCxnxrUyhUJhXbKA==}
+    engines: {node: '>=20.9.0'}
     cpu: [arm64]
     os: [win32]
 
@@ -965,9 +1111,21 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@img/sharp-win32-ia32@0.35.0':
+    resolution: {integrity: sha512-z0+pZ03QCDvdVN0Ez9IX/yjWC19ikMlXrmdYMwYNLTh2BLPx3hXWPvyqWfquZ0BTO9O6GVOjIVoTcyyacMnWlQ==}
+    engines: {node: ^20.9.0}
+    cpu: [ia32]
+    os: [win32]
+
   '@img/sharp-win32-x64@0.34.5':
     resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.35.0':
+    resolution: {integrity: sha512-feNnlz5ZHKr0MY1LPHvZQyJeBkbo4ctsn0D8FvA53VTw5TC63rfEL2UrWbkSBR19htSE7Mw78xYVwdJqoMWVHw==}
+    engines: {node: '>=20.9.0'}
     cpu: [x64]
     os: [win32]
 
@@ -3037,14 +3195,6 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  b4a@1.7.3:
-    resolution: {integrity: sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==}
-    peerDependencies:
-      react-native-b4a: '*'
-    peerDependenciesMeta:
-      react-native-b4a:
-        optional: true
-
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
@@ -3054,44 +3204,6 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
-
-  bare-events@2.8.2:
-    resolution: {integrity: sha512-riJjyv1/mHLIPX4RwiK+oW9/4c3TEUeORHKefKAKnZ5kyslbN+HXowtbaVEqt4IMUB7OXlfixcs6gsFeo/jhiQ==}
-    peerDependencies:
-      bare-abort-controller: '*'
-    peerDependenciesMeta:
-      bare-abort-controller:
-        optional: true
-
-  bare-fs@4.5.2:
-    resolution: {integrity: sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==}
-    engines: {bare: '>=1.16.0'}
-    peerDependencies:
-      bare-buffer: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-
-  bare-os@3.6.2:
-    resolution: {integrity: sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==}
-    engines: {bare: '>=1.14.0'}
-
-  bare-path@3.0.0:
-    resolution: {integrity: sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==}
-
-  bare-stream@2.7.0:
-    resolution: {integrity: sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==}
-    peerDependencies:
-      bare-buffer: '*'
-      bare-events: '*'
-    peerDependenciesMeta:
-      bare-buffer:
-        optional: true
-      bare-events:
-        optional: true
-
-  bare-url@2.3.2:
-    resolution: {integrity: sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -3171,9 +3283,6 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
-  chownr@1.1.4:
-    resolution: {integrity: sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==}
-
   citeproc@2.4.63:
     resolution: {integrity: sha512-68F95Bp4UbgZU/DBUGQn0qV3HDZLCdI9+Bb2ByrTaNJDL5VEm9LqaiNaxljsvoaExSLEXe1/r6n2Z06SCzW3/Q==}
 
@@ -3217,13 +3326,6 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-
-  color-string@1.9.1:
-    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
-
-  color@4.2.3:
-    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
-    engines: {node: '>=12.5.0'}
 
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
@@ -3309,16 +3411,8 @@ packages:
   decode-named-character-reference@1.2.0:
     resolution: {integrity: sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q==}
 
-  decompress-response@6.0.0:
-    resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
-    engines: {node: '>=10'}
-
   dedent@0.7.0:
     resolution: {integrity: sha512-Q6fKUPqnAHAyhiUgFU7BUzLiv0kd8saH9al7tnu5Q/okj6dnupxyTgFIBjVzJATdfIAm9NAsvXNzjaKa+bxVyA==}
-
-  deep-extend@0.6.0:
-    resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
-    engines: {node: '>=4.0.0'}
 
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
@@ -3382,9 +3476,6 @@ packages:
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
-
-  end-of-stream@1.4.5:
-    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   enhanced-resolve@5.18.4:
     resolution: {integrity: sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==}
@@ -3637,13 +3728,6 @@ packages:
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
-  events-universal@1.0.1:
-    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
-
-  expand-template@2.0.3:
-    resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
-    engines: {node: '>=6'}
-
   extend-shallow@2.0.1:
     resolution: {integrity: sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==}
     engines: {node: '>=0.10.0'}
@@ -3656,9 +3740,6 @@ packages:
 
   fast-diff@1.3.0:
     resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
-
-  fast-fifo@1.3.2:
-    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -3741,9 +3822,6 @@ packages:
       react-dom:
         optional: true
 
-  fs-constants@1.0.0:
-    resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
-
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
@@ -3784,9 +3862,6 @@ packages:
 
   get-tsconfig@4.13.0:
     resolution: {integrity: sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==}
-
-  github-from-package@0.0.0:
-    resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
 
   github-slugger@2.0.0:
     resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
@@ -3977,9 +4052,6 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
-  ini@1.3.8:
-    resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
-
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
@@ -4003,9 +4075,6 @@ packages:
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
     engines: {node: '>= 0.4'}
-
-  is-arrayish@0.3.4:
-    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-async-function@2.1.1:
     resolution: {integrity: sha512-9dgM/cZBnNvjzaMYHVoxxfPj2QXt22Ev7SuuPrs+xav0ukGB0S6d4ydZdEiM48kLx5kDV+QBPrpVnFyefL8kkQ==}
@@ -4546,10 +4615,6 @@ packages:
     resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
     engines: {node: '>=18'}
 
-  mimic-response@3.1.0:
-    resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
-    engines: {node: '>=10'}
-
   mini-svg-data-uri@1.4.4:
     resolution: {integrity: sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==}
     hasBin: true
@@ -4563,9 +4628,6 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
-
-  mkdirp-classic@0.5.3:
-    resolution: {integrity: sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==}
 
   moo@0.5.2:
     resolution: {integrity: sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==}
@@ -4614,9 +4676,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  napi-build-utils@2.0.0:
-    resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
-
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -4648,13 +4707,6 @@ packages:
 
   nlcst-to-string@3.1.1:
     resolution: {integrity: sha512-63mVyqaqt0cmn2VcI2aH6kxe1rLAmSROqHMA0i4qqg1tidkfExgpb0FGMikMCn86mw5dFtBtEANfmSSK7TjNHw==}
-
-  node-abi@3.85.0:
-    resolution: {integrity: sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==}
-    engines: {node: '>=10'}
-
-  node-addon-api@6.1.0:
-    resolution: {integrity: sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==}
 
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
@@ -4711,9 +4763,6 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
-
-  once@1.4.0:
-    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -4838,12 +4887,6 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  prebuild-install@7.1.3:
-    resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
-    engines: {node: '>=10'}
-    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
-    hasBin: true
-
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -4866,9 +4909,6 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
-  pump@3.0.3:
-    resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -4888,10 +4928,6 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
-
-  rc@1.2.8:
-    resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
-    hasBin: true
 
   react-aria-components@1.14.0:
     resolution: {integrity: sha512-u21N/yS6Ozk9P9oO8wxMNZSFiPk6F3aAE9w6aN7pseGPApkjXqDyPNCnTsTTvMtVL3QRBkVbf7fJ5yi2hksVEg==}
@@ -5155,11 +5191,6 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.7.3:
-    resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
@@ -5181,13 +5212,13 @@ packages:
     resolution: {integrity: sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw==}
     engines: {node: '>= 0.4'}
 
-  sharp@0.32.6:
-    resolution: {integrity: sha512-KyLTWwgcR9Oe4d9HwCwNM2l7+J0dUQwn/yf7S0EnTtb0eVS4RxO0eUSvxPtzT4F3SY+C4K6fqdv/DO27sJ/v/w==}
-    engines: {node: '>=14.15.0'}
-
   sharp@0.34.5:
     resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  sharp@0.35.0:
+    resolution: {integrity: sha512-BqvG5XbwPZ4NV0DK90d86leEECMsoa8bO0nqnKWlBDYxri4GJ7c4EDInaF6q20lTh/mATmnDIKWJFfXnoVfH5g==}
+    engines: {node: '>=20.9.0'}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5224,15 +5255,6 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
-  simple-concat@1.0.1:
-    resolution: {integrity: sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==}
-
-  simple-get@4.0.1:
-    resolution: {integrity: sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==}
-
-  simple-swizzle@0.2.4:
-    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
-
   sirv@2.0.4:
     resolution: {integrity: sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==}
     engines: {node: '>= 10'}
@@ -5265,9 +5287,6 @@ packages:
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
-
-  streamx@2.23.0:
-    resolution: {integrity: sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==}
 
   string-argv@0.3.2:
     resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
@@ -5330,10 +5349,6 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
-  strip-json-comments@2.0.1:
-    resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
-    engines: {node: '>=0.10.0'}
-
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
@@ -5384,22 +5399,6 @@ packages:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
     engines: {node: '>=6'}
 
-  tar-fs@2.1.4:
-    resolution: {integrity: sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==}
-
-  tar-fs@3.1.1:
-    resolution: {integrity: sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==}
-
-  tar-stream@2.2.0:
-    resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
-    engines: {node: '>=6'}
-
-  tar-stream@3.1.7:
-    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
-
-  text-decoder@1.2.3:
-    resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
-
   through@2.3.8:
     resolution: {integrity: sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==}
 
@@ -5439,9 +5438,6 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  tunnel-agent@0.6.0:
-    resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -5654,9 +5650,6 @@ packages:
   wrap-ansi@9.0.2:
     resolution: {integrity: sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==}
     engines: {node: '>=18'}
-
-  wrappy@1.0.2:
-    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
   ws@7.5.10:
     resolution: {integrity: sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==}
@@ -6193,12 +6186,16 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.1.0':
-    optional: true
+  '@img/colour@1.1.0': {}
 
   '@img/sharp-darwin-arm64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.35.0':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.3.0
     optional: true
 
   '@img/sharp-darwin-x64@0.34.5':
@@ -6206,34 +6203,74 @@ snapshots:
       '@img/sharp-libvips-darwin-x64': 1.2.4
     optional: true
 
+  '@img/sharp-darwin-x64@0.35.0':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.3.0
+    optional: true
+
+  '@img/sharp-freebsd-wasm32@0.35.0':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.0
+    optional: true
+
   '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.3.0':
     optional: true
 
   '@img/sharp-libvips-darwin-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-darwin-x64@1.3.0':
+    optional: true
+
   '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.3.0':
     optional: true
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-arm@1.3.0':
+    optional: true
+
   '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.3.0':
     optional: true
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-riscv64@1.3.0':
+    optional: true
+
   '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.3.0':
     optional: true
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linux-x64@1.3.0':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     optional: true
 
+  '@img/sharp-libvips-linuxmusl-arm64@1.3.0':
+    optional: true
+
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.3.0':
     optional: true
 
   '@img/sharp-linux-arm64@0.34.5':
@@ -6241,9 +6278,19 @@ snapshots:
       '@img/sharp-libvips-linux-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-arm64@0.35.0':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.3.0
+    optional: true
+
   '@img/sharp-linux-arm@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.35.0':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.3.0
     optional: true
 
   '@img/sharp-linux-ppc64@0.34.5':
@@ -6251,9 +6298,19 @@ snapshots:
       '@img/sharp-libvips-linux-ppc64': 1.2.4
     optional: true
 
+  '@img/sharp-linux-ppc64@0.35.0':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.3.0
+    optional: true
+
   '@img/sharp-linux-riscv64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.35.0':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.3.0
     optional: true
 
   '@img/sharp-linux-s390x@0.34.5':
@@ -6261,9 +6318,19 @@ snapshots:
       '@img/sharp-libvips-linux-s390x': 1.2.4
     optional: true
 
+  '@img/sharp-linux-s390x@0.35.0':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.3.0
+    optional: true
+
   '@img/sharp-linux-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.35.0':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.3.0
     optional: true
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
@@ -6271,9 +6338,19 @@ snapshots:
       '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
     optional: true
 
+  '@img/sharp-linuxmusl-arm64@0.35.0':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.0
+    optional: true
+
   '@img/sharp-linuxmusl-x64@0.34.5':
     optionalDependencies:
       '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.35.0':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.0
     optional: true
 
   '@img/sharp-wasm32@0.34.5':
@@ -6281,13 +6358,32 @@ snapshots:
       '@emnapi/runtime': 1.11.3
     optional: true
 
+  '@img/sharp-wasm32@0.35.0':
+    dependencies:
+      '@emnapi/runtime': 1.11.3
+    optional: true
+
+  '@img/sharp-webcontainers-wasm32@0.35.0':
+    dependencies:
+      '@img/sharp-wasm32': 0.35.0
+    optional: true
+
   '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-arm64@0.35.0':
     optional: true
 
   '@img/sharp-win32-ia32@0.34.5':
     optional: true
 
+  '@img/sharp-win32-ia32@0.35.0':
+    optional: true
+
   '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.35.0':
     optional: true
 
   '@inquirer/external-editor@1.0.3(@types/node@24.10.1)':
@@ -8813,50 +8909,11 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  b4a@1.7.3: {}
-
   bail@2.0.2: {}
 
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
-
-  bare-events@2.8.2: {}
-
-  bare-fs@4.5.2:
-    dependencies:
-      bare-events: 2.8.2
-      bare-path: 3.0.0
-      bare-stream: 2.7.0(bare-events@2.8.2)
-      bare-url: 2.3.2
-      fast-fifo: 1.3.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-    optional: true
-
-  bare-os@3.6.2:
-    optional: true
-
-  bare-path@3.0.0:
-    dependencies:
-      bare-os: 3.6.2
-    optional: true
-
-  bare-stream@2.7.0(bare-events@2.8.2):
-    dependencies:
-      streamx: 2.23.0
-    optionalDependencies:
-      bare-events: 2.8.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-    optional: true
-
-  bare-url@2.3.2:
-    dependencies:
-      bare-path: 3.0.0
-    optional: true
 
   base64-js@1.5.1: {}
 
@@ -8938,8 +8995,6 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  chownr@1.1.4: {}
-
   citeproc@2.4.63: {}
 
   cli-cursor@3.1.0:
@@ -8972,16 +9027,6 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
-
-  color-string@1.9.1:
-    dependencies:
-      color-name: 1.1.4
-      simple-swizzle: 0.2.4
-
-  color@4.2.3:
-    dependencies:
-      color-convert: 2.0.1
-      color-string: 1.9.1
 
   colorette@2.0.20: {}
 
@@ -9053,13 +9098,7 @@ snapshots:
     dependencies:
       character-entities: 2.0.2
 
-  decompress-response@6.0.0:
-    dependencies:
-      mimic-response: 3.1.0
-
   dedent@0.7.0: {}
-
-  deep-extend@0.6.0: {}
 
   deep-is@0.1.4: {}
 
@@ -9119,10 +9158,6 @@ snapshots:
   encoding@0.1.13:
     dependencies:
       iconv-lite: 0.6.3
-
-  end-of-stream@1.4.5:
-    dependencies:
-      once: 1.4.0
 
   enhanced-resolve@5.18.4:
     dependencies:
@@ -9576,14 +9611,6 @@ snapshots:
 
   eventemitter3@5.0.4: {}
 
-  events-universal@1.0.1:
-    dependencies:
-      bare-events: 2.8.2
-    transitivePeerDependencies:
-      - bare-abort-controller
-
-  expand-template@2.0.3: {}
-
   extend-shallow@2.0.1:
     dependencies:
       is-extendable: 0.1.1
@@ -9593,8 +9620,6 @@ snapshots:
   fast-deep-equal@3.1.3: {}
 
   fast-diff@1.3.0: {}
-
-  fast-fifo@1.3.2: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -9677,8 +9702,6 @@ snapshots:
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
 
-  fs-constants@1.0.0: {}
-
   function-bind@1.1.2: {}
 
   function.prototype.name@1.1.8:
@@ -9727,8 +9750,6 @@ snapshots:
   get-tsconfig@4.13.0:
     dependencies:
       resolve-pkg-maps: 1.0.0
-
-  github-from-package@0.0.0: {}
 
   github-slugger@2.0.0: {}
 
@@ -10012,8 +10033,6 @@ snapshots:
 
   inherits@2.0.4: {}
 
-  ini@1.3.8: {}
-
   inline-style-parser@0.2.7: {}
 
   inquirer@8.2.7(@types/node@24.10.1):
@@ -10061,8 +10080,6 @@ snapshots:
       call-bind: 1.0.8
       call-bound: 1.0.4
       get-intrinsic: 1.3.0
-
-  is-arrayish@0.3.4: {}
 
   is-async-function@2.1.1:
     dependencies:
@@ -10872,8 +10889,6 @@ snapshots:
 
   mimic-function@5.0.1: {}
 
-  mimic-response@3.1.0: {}
-
   mini-svg-data-uri@1.4.4: {}
 
   minimatch@10.2.4:
@@ -10885,8 +10900,6 @@ snapshots:
       brace-expansion: 1.1.12
 
   minimist@1.2.8: {}
-
-  mkdirp-classic@0.5.3: {}
 
   moo@0.5.2: {}
 
@@ -10915,8 +10928,6 @@ snapshots:
   nanoid@3.3.11: {}
 
   nanoid@3.3.16: {}
-
-  napi-build-utils@2.0.0: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -10951,12 +10962,6 @@ snapshots:
   nlcst-to-string@3.1.1:
     dependencies:
       '@types/nlcst': 1.0.4
-
-  node-abi@3.85.0:
-    dependencies:
-      semver: 7.8.5
-
-  node-addon-api@6.1.0: {}
 
   node-addon-api@7.1.1:
     optional: true
@@ -11016,10 +11021,6 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
-
-  once@1.4.0:
-    dependencies:
-      wrappy: 1.0.2
 
   onetime@5.1.2:
     dependencies:
@@ -11157,21 +11158,6 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  prebuild-install@7.1.3:
-    dependencies:
-      detect-libc: 2.1.2
-      expand-template: 2.0.3
-      github-from-package: 0.0.0
-      minimist: 1.2.8
-      mkdirp-classic: 0.5.3
-      napi-build-utils: 2.0.0
-      node-abi: 3.85.0
-      pump: 3.0.3
-      rc: 1.2.8
-      simple-get: 4.0.1
-      tar-fs: 2.1.4
-      tunnel-agent: 0.6.0
-
   prelude-ls@1.2.1: {}
 
   prettier-linter-helpers@1.0.0:
@@ -11189,11 +11175,6 @@ snapshots:
   property-information@6.5.0: {}
 
   property-information@7.1.0: {}
-
-  pump@3.0.3:
-    dependencies:
-      end-of-stream: 1.4.5
-      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -11260,13 +11241,6 @@ snapshots:
       react-dom: 19.0.0(react@19.0.0)
     optionalDependencies:
       '@types/react': 18.3.12
-
-  rc@1.2.8:
-    dependencies:
-      deep-extend: 0.6.0
-      ini: 1.3.8
-      minimist: 1.2.8
-      strip-json-comments: 2.0.1
 
   react-aria-components@1.14.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
@@ -11762,8 +11736,6 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.7.3: {}
-
   semver@7.8.5: {}
 
   serialize-javascript@7.0.4: {}
@@ -11789,21 +11761,6 @@ snapshots:
       dunder-proto: 1.0.1
       es-errors: 1.3.0
       es-object-atoms: 1.1.1
-
-  sharp@0.32.6:
-    dependencies:
-      color: 4.2.3
-      detect-libc: 2.1.2
-      node-addon-api: 6.1.0
-      prebuild-install: 7.1.3
-      semver: 7.7.3
-      simple-get: 4.0.1
-      tar-fs: 3.1.1
-      tunnel-agent: 0.6.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
 
   sharp@0.34.5:
     dependencies:
@@ -11836,6 +11793,38 @@ snapshots:
       '@img/sharp-win32-ia32': 0.34.5
       '@img/sharp-win32-x64': 0.34.5
     optional: true
+
+  sharp@0.35.0:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.5
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.35.0
+      '@img/sharp-darwin-x64': 0.35.0
+      '@img/sharp-freebsd-wasm32': 0.35.0
+      '@img/sharp-libvips-darwin-arm64': 1.3.0
+      '@img/sharp-libvips-darwin-x64': 1.3.0
+      '@img/sharp-libvips-linux-arm': 1.3.0
+      '@img/sharp-libvips-linux-arm64': 1.3.0
+      '@img/sharp-libvips-linux-ppc64': 1.3.0
+      '@img/sharp-libvips-linux-riscv64': 1.3.0
+      '@img/sharp-libvips-linux-s390x': 1.3.0
+      '@img/sharp-libvips-linux-x64': 1.3.0
+      '@img/sharp-libvips-linuxmusl-arm64': 1.3.0
+      '@img/sharp-libvips-linuxmusl-x64': 1.3.0
+      '@img/sharp-linux-arm': 0.35.0
+      '@img/sharp-linux-arm64': 0.35.0
+      '@img/sharp-linux-ppc64': 0.35.0
+      '@img/sharp-linux-riscv64': 0.35.0
+      '@img/sharp-linux-s390x': 0.35.0
+      '@img/sharp-linux-x64': 0.35.0
+      '@img/sharp-linuxmusl-arm64': 0.35.0
+      '@img/sharp-linuxmusl-x64': 0.35.0
+      '@img/sharp-webcontainers-wasm32': 0.35.0
+      '@img/sharp-win32-arm64': 0.35.0
+      '@img/sharp-win32-ia32': 0.35.0
+      '@img/sharp-win32-x64': 0.35.0
 
   shebang-command@2.0.0:
     dependencies:
@@ -11886,18 +11875,6 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
-  simple-concat@1.0.1: {}
-
-  simple-get@4.0.1:
-    dependencies:
-      decompress-response: 6.0.0
-      once: 1.4.0
-      simple-concat: 1.0.1
-
-  simple-swizzle@0.2.4:
-    dependencies:
-      is-arrayish: 0.3.4
-
   sirv@2.0.4:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -11925,15 +11902,6 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
-
-  streamx@2.23.0:
-    dependencies:
-      events-universal: 1.0.1
-      fast-fifo: 1.3.2
-      text-decoder: 1.2.3
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
 
   string-argv@0.3.2: {}
 
@@ -12025,8 +11993,6 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
-  strip-json-comments@2.0.1: {}
-
   strip-json-comments@3.1.1: {}
 
   style-to-js@1.1.21:
@@ -12067,48 +12033,6 @@ snapshots:
 
   tapable@2.3.0: {}
 
-  tar-fs@2.1.4:
-    dependencies:
-      chownr: 1.1.4
-      mkdirp-classic: 0.5.3
-      pump: 3.0.3
-      tar-stream: 2.2.0
-
-  tar-fs@3.1.1:
-    dependencies:
-      pump: 3.0.3
-      tar-stream: 3.1.7
-    optionalDependencies:
-      bare-fs: 4.5.2
-      bare-path: 3.0.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - bare-buffer
-      - react-native-b4a
-
-  tar-stream@2.2.0:
-    dependencies:
-      bl: 4.1.0
-      end-of-stream: 1.4.5
-      fs-constants: 1.0.0
-      inherits: 2.0.4
-      readable-stream: 3.6.2
-
-  tar-stream@3.1.7:
-    dependencies:
-      b4a: 1.7.3
-      fast-fifo: 1.3.2
-      streamx: 2.23.0
-    transitivePeerDependencies:
-      - bare-abort-controller
-      - react-native-b4a
-
-  text-decoder@1.2.3:
-    dependencies:
-      b4a: 1.7.3
-    transitivePeerDependencies:
-      - react-native-b4a
-
   through@2.3.8: {}
 
   tinyglobby@0.2.15:
@@ -12144,10 +12068,6 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
-
-  tunnel-agent@0.6.0:
-    dependencies:
-      safe-buffer: 5.2.1
 
   type-check@0.4.0:
     dependencies:
@@ -12478,8 +12398,6 @@ snapshots:
       ansi-styles: 6.2.3
       string-width: 7.2.0
       strip-ansi: 7.1.2
-
-  wrappy@1.0.2: {}
 
   ws@7.5.10: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 0.2.2(@content-collections/core@0.14.2(typescript@5.7.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@content-collections/next':
         specifier: ^0.2.11
-        version: 0.2.11(@content-collections/core@0.14.2(typescript@5.7.2))(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2))
+        version: 0.2.11(@content-collections/core@0.14.2(typescript@5.7.2))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2))
       '@jsdevtools/rehype-toc':
         specifier: ^3.0.2
         version: 3.0.2
@@ -102,8 +102,8 @@ importers:
         specifier: ^12.23.25
         version: 12.23.25(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next:
-        specifier: ^16.2.0
-        version: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2)
+        specifier: ^16.2.6
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2)
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -393,8 +393,8 @@ packages:
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
 
-  '@emnapi/runtime@1.7.1':
-    resolution: {integrity: sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==}
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
@@ -818,8 +818,8 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@img/colour@1.0.0':
-    resolution: {integrity: sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==}
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -1040,8 +1040,8 @@ packages:
   '@next/bundle-analyzer@16.2.1':
     resolution: {integrity: sha512-fbj2WE6dnCyG8CvQnrBfpHyxdOIyZ4aEHJY0bSqAmamRiIXDqunFQPDvuSOPo24mJE9zQHw7TY6d+sGrXO98TQ==}
 
-  '@next/env@16.2.1':
-    resolution: {integrity: sha512-n8P/HCkIWW+gVal2Z8XqXJ6aB3J0tuM29OcHpCsobWlChH/SITBs1DFBk/HajgrwDkqqBXPbuUuzgDvUekREPg==}
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
   '@next/eslint-plugin-next@16.2.1':
     resolution: {integrity: sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA==}
@@ -1057,54 +1057,54 @@ packages:
       '@mdx-js/react':
         optional: true
 
-  '@next/swc-darwin-arm64@16.2.1':
-    resolution: {integrity: sha512-BwZ8w8YTaSEr2HIuXLMLxIdElNMPvY9fLqb20LX9A9OMGtJilhHLbCL3ggyd0TwjmMcTxi0XXt+ur1vWUoxj2Q==}
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.1':
-    resolution: {integrity: sha512-/vrcE6iQSJq3uL3VGVHiXeaKbn8Es10DGTGRJnRZlkNQQk3kaNtAJg8Y6xuAlrx/6INKVjkfi5rY0iEXorZ6uA==}
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.1':
-    resolution: {integrity: sha512-uLn+0BK+C31LTVbQ/QU+UaVrV0rRSJQ8RfniQAHPghDdgE+SlroYqcmFnO5iNjNfVWCyKZHYrs3Nl0mUzWxbBw==}
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.1':
-    resolution: {integrity: sha512-ssKq6iMRnHdnycGp9hCuGnXJZ0YPr4/wNwrfE5DbmvEcgl9+yv97/Kq3TPVDfYome1SW5geciLB9aiEqKXQjlQ==}
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.1':
-    resolution: {integrity: sha512-HQm7SrHRELJ30T1TSmT706IWovFFSRGxfgUkyWJZF/RKBMdbdRWJuFrcpDdE5vy9UXjFOx6L3mRdqH04Mmx0hg==}
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.1':
-    resolution: {integrity: sha512-aV2iUaC/5HGEpbBkE+4B8aHIudoOy5DYekAKOMSHoIYQ66y/wIVeaRx8MS2ZMdxe/HIXlMho4ubdZs/J8441Tg==}
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.1':
-    resolution: {integrity: sha512-IXdNgiDHaSk0ZUJ+xp0OQTdTgnpx1RCfRTalhn3cjOP+IddTMINwA7DXZrwTmGDO8SUr5q2hdP/du4DcrB1GxA==}
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.1':
-    resolution: {integrity: sha512-qvU+3a39Hay+ieIztkGSbF7+mccbbg1Tk25hc4JDylf8IHjYmY/Zm64Qq1602yPyQqvie+vf5T/uPwNxDNIoeg==}
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3142,8 +3142,8 @@ packages:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
 
-  caniuse-lite@1.0.30001759:
-    resolution: {integrity: sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw==}
+  caniuse-lite@1.0.30001792:
+    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -4609,6 +4609,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   napi-build-utils@2.0.0:
     resolution: {integrity: sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==}
 
@@ -4620,8 +4625,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@16.2.1:
-    resolution: {integrity: sha512-VaChzNL7o9rbfdt60HUj8tev4m6d7iC1igAy157526+cJlXOQu5LzsBXNT+xaJnTP/k+utSX5vMv7m0G+zKH+Q==}
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5152,6 +5157,11 @@ packages:
 
   semver@7.7.3:
     resolution: {integrity: sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5872,11 +5882,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@content-collections/next@0.2.11(@content-collections/core@0.14.2(typescript@5.7.2))(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2))':
+  '@content-collections/next@0.2.11(@content-collections/core@0.14.2(typescript@5.7.2))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2))':
     dependencies:
       '@content-collections/core': 0.14.2(typescript@5.7.2)
       '@content-collections/integrations': 0.5.0(@content-collections/core@0.14.2(typescript@5.7.2))
-      next: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2)
 
   '@csstools/selector-resolve-nested@1.1.0(postcss-selector-parser@6.1.2)':
     dependencies:
@@ -5894,7 +5904,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.7.1':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6183,7 +6193,7 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@img/colour@1.0.0':
+  '@img/colour@1.1.0':
     optional: true
 
   '@img/sharp-darwin-arm64@0.34.5':
@@ -6268,7 +6278,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.7.1
+      '@emnapi/runtime': 1.10.0
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -6382,7 +6392,7 @@ snapshots:
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.7.1
-      '@emnapi/runtime': 1.7.1
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -6393,7 +6403,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@next/env@16.2.1': {}
+  '@next/env@16.2.6': {}
 
   '@next/eslint-plugin-next@16.2.1':
     dependencies:
@@ -6406,28 +6416,28 @@ snapshots:
       '@mdx-js/loader': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@18.3.12)(react@19.0.0)
 
-  '@next/swc-darwin-arm64@16.2.1':
+  '@next/swc-darwin-arm64@16.2.6':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.1':
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.1':
+  '@next/swc-linux-arm64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.1':
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.1':
+  '@next/swc-linux-x64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.1':
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.1':
+  '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.1':
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -8587,7 +8597,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
       minimatch: 10.2.4
-      semver: 7.7.3
+      semver: 7.8.0
       tinyglobby: 0.2.15
       ts-api-utils: 2.5.0(typescript@5.7.2)
       typescript: 5.7.2
@@ -8874,7 +8884,7 @@ snapshots:
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001759
+      caniuse-lite: 1.0.30001792
       electron-to-chromium: 1.5.328
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
@@ -8905,7 +8915,7 @@ snapshots:
 
   camelcase@8.0.0: {}
 
-  caniuse-lite@1.0.30001759: {}
+  caniuse-lite@1.0.30001792: {}
 
   ccount@2.0.1: {}
 
@@ -10075,7 +10085,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.0
 
   is-callable@1.2.7: {}
 
@@ -10904,31 +10914,33 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.12: {}
+
   napi-build-utils@2.0.0: {}
 
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
 
-  next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2):
+  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2):
     dependencies:
-      '@next/env': 16.2.1
+      '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001759
+      caniuse-lite: 1.0.30001792
       postcss: 8.4.31
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.0.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.1
-      '@next/swc-darwin-x64': 16.2.1
-      '@next/swc-linux-arm64-gnu': 16.2.1
-      '@next/swc-linux-arm64-musl': 16.2.1
-      '@next/swc-linux-x64-gnu': 16.2.1
-      '@next/swc-linux-x64-musl': 16.2.1
-      '@next/swc-win32-arm64-msvc': 16.2.1
-      '@next/swc-win32-x64-msvc': 16.2.1
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.9.0
       sass: 1.94.2
       sharp: 0.34.5
@@ -10942,7 +10954,7 @@ snapshots:
 
   node-abi@3.85.0:
     dependencies:
-      semver: 7.7.3
+      semver: 7.8.0
 
   node-addon-api@6.1.0: {}
 
@@ -11135,7 +11147,7 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.12
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -11752,6 +11764,8 @@ snapshots:
 
   semver@7.7.3: {}
 
+  semver@7.8.0: {}
+
   serialize-javascript@7.0.4: {}
 
   set-function-length@1.2.2:
@@ -11793,9 +11807,9 @@ snapshots:
 
   sharp@0.34.5:
     dependencies:
-      '@img/colour': 1.0.0
+      '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.7.3
+      semver: 7.8.0
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,11 +105,11 @@ importers:
         specifier: ^16.2.11
         version: 16.2.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2)
       postcss:
-        specifier: ^8.5.10
-        version: 8.5.10
+        specifier: ^8.5.18
+        version: 8.5.18
       postcss-nesting:
         specifier: ^12.1.5
-        version: 12.1.5(postcss@8.5.10)
+        version: 12.1.5(postcss@8.5.18)
       radix-ui:
         specifier: ^1.4.3
         version: 1.4.3(@types/react@18.3.12)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -4666,11 +4666,6 @@ packages:
     resolution: {integrity: sha512-tacvGzUY5o2D8CBh2rrwxyNojUsZNU2zjNTzKQrkgGJQTbGAfArVWXSKMBokBeeg6C7OLRGUEyoFlYbfeWQIqw==}
     engines: {node: '>=20.17'}
 
-  nanoid@3.3.11:
-    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   nanoid@3.3.16:
     resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -4883,8 +4878,8 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.10:
-    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+  postcss@8.5.18:
+    resolution: {integrity: sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==}
     engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
@@ -8547,7 +8542,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.18
       '@tailwindcss/oxide': 4.1.18
-      postcss: 8.5.10
+      postcss: 8.5.18
       tailwindcss: 4.1.18
 
   '@tailwindcss/typography@0.5.19(tailwindcss@4.1.18)':
@@ -10925,8 +10920,6 @@ snapshots:
 
   nano-spawn@2.0.0: {}
 
-  nanoid@3.3.11: {}
-
   nanoid@3.3.16: {}
 
   napi-postinstall@0.3.4: {}
@@ -11129,11 +11122,11 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss-nesting@12.1.5(postcss@8.5.10):
+  postcss-nesting@12.1.5(postcss@8.5.18):
     dependencies:
       '@csstools/selector-resolve-nested': 1.1.0(postcss-selector-parser@6.1.2)
       '@csstools/selector-specificity': 3.1.1(postcss-selector-parser@6.1.2)
-      postcss: 8.5.10
+      postcss: 8.5.18
       postcss-selector-parser: 6.1.2
 
   postcss-selector-parser@6.0.10:
@@ -11152,9 +11145,9 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  postcss@8.5.10:
+  postcss@8.5.18:
     dependencies:
-      nanoid: 3.3.11
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 0.2.2(@content-collections/core@0.14.2(typescript@5.7.2))(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@content-collections/next':
         specifier: ^0.2.11
-        version: 0.2.11(@content-collections/core@0.14.2(typescript@5.7.2))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2))
+        version: 0.2.11(@content-collections/core@0.14.2(typescript@5.7.2))(next@16.2.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2))
       '@jsdevtools/rehype-toc':
         specifier: ^3.0.2
         version: 3.0.2
@@ -102,8 +102,8 @@ importers:
         specifier: ^12.23.25
         version: 12.23.25(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       next:
-        specifier: ^16.2.6
-        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2)
+        specifier: ^16.2.11
+        version: 16.2.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2)
       postcss:
         specifier: ^8.5.10
         version: 8.5.10
@@ -393,8 +393,8 @@ packages:
   '@emnapi/core@1.7.1':
     resolution: {integrity: sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==}
 
-  '@emnapi/runtime@1.10.0':
-    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+  '@emnapi/runtime@1.11.3':
+    resolution: {integrity: sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==}
 
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
@@ -1040,8 +1040,8 @@ packages:
   '@next/bundle-analyzer@16.2.1':
     resolution: {integrity: sha512-fbj2WE6dnCyG8CvQnrBfpHyxdOIyZ4aEHJY0bSqAmamRiIXDqunFQPDvuSOPo24mJE9zQHw7TY6d+sGrXO98TQ==}
 
-  '@next/env@16.2.6':
-    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
+  '@next/env@16.2.11':
+    resolution: {integrity: sha512-0do5A3BJ2gxWr0ZCMcD6BhW+e595jyxdTl3rXTS6lOtD8ektMiW6CO+EPwt1Eca1DBnm90r/7GdiKWBKxH++DA==}
 
   '@next/eslint-plugin-next@16.2.1':
     resolution: {integrity: sha512-r0epZGo24eT4g08jJlg2OEryBphXqO8aL18oajoTKLzHJ6jVr6P6FI58DLMug04MwD3j8Fj0YK0slyzneKVyzA==}
@@ -1057,54 +1057,54 @@ packages:
       '@mdx-js/react':
         optional: true
 
-  '@next/swc-darwin-arm64@16.2.6':
-    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
+  '@next/swc-darwin-arm64@16.2.11':
+    resolution: {integrity: sha512-wryL4pjKmDwGv2ox6+GZDFxvmtSRLqApBR8kL1j4+vhB7Z5vJC/zAnXpiR9Xkfzl0AS8WLMnsuGV/UKI67/rrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.6':
-    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
+  '@next/swc-darwin-x64@16.2.11':
+    resolution: {integrity: sha512-aZl2j4f/fLyjQvOhv0Oe9UaMAQHolYpKhctsoYzplSumKJKPUmgjcf6545aBtysLTcu994TREd0+pSgNE4ohmg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.6':
-    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
+  '@next/swc-linux-arm64-gnu@16.2.11':
+    resolution: {integrity: sha512-5jEriyEnH/LWFy27L2ZG0XaLlyEJIjhsImEsiS9P563PKEVp2BVups/xfOucIrsvVntp11oNcZwjHvaDPYVB5g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.6':
-    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
+  '@next/swc-linux-arm64-musl@16.2.11':
+    resolution: {integrity: sha512-eIjcpx2fnnFSSkZDbTxy74KnokUXDjfoLClpWelfgHLf621aTqswhwXQ7GkD5K5rplrS6LZ/Bj+mVuvzluBOEg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.6':
-    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
+  '@next/swc-linux-x64-gnu@16.2.11':
+    resolution: {integrity: sha512-8WgzpaWMs46qJT9kiV47cje86L0x/Mu9t8/Gwj+pnbgW3rETVfCnaScPjlYUwNScpOozdcIMHWmAvuZJUonR2w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.6':
-    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
+  '@next/swc-linux-x64-musl@16.2.11':
+    resolution: {integrity: sha512-I3UgPds7G4ZYnTb/H+5GBGuUT2DhAk6j0mL6A4s63RjFs74wB2hOWP0vaxsK+3NJraExt3eYEPQ/UtT0x/64Nw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.6':
-    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
+  '@next/swc-win32-arm64-msvc@16.2.11':
+    resolution: {integrity: sha512-n89CjtcThnjrwgJMAiI5xbqwLY51zvwC9tSlArmVndAJLYVl9T9UAdlkXTmZvE++idoXe8KdglQlhNRdUp1c6g==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.6':
-    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
+  '@next/swc-win32-x64-msvc@16.2.11':
+    resolution: {integrity: sha512-md8CLNggS1Dx9pUgApzps5uAf+N8GN9xywzmNx9vHAWo94HtBwCCqkSnhIrdfQe83Dhz8Lfo/20Nb1Zxal092w==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3142,8 +3142,8 @@ packages:
     resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
     engines: {node: '>=16'}
 
-  caniuse-lite@1.0.30001792:
-    resolution: {integrity: sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw==}
+  caniuse-lite@1.0.30001806:
+    resolution: {integrity: sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==}
 
   ccount@2.0.1:
     resolution: {integrity: sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==}
@@ -4609,8 +4609,8 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.16:
+    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4625,8 +4625,8 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  next@16.2.6:
-    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
+  next@16.2.11:
+    resolution: {integrity: sha512-B339zaqbyK8cmxhoAvLrcwoabwCP1wz21zSzfqxqXAemTu2BXnH7tQnfcglKv1vnMUIDBc+Hth7XODQriTZiRQ==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5160,8 +5160,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.8.0:
-    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5882,11 +5882,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@content-collections/next@0.2.11(@content-collections/core@0.14.2(typescript@5.7.2))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2))':
+  '@content-collections/next@0.2.11(@content-collections/core@0.14.2(typescript@5.7.2))(next@16.2.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2))':
     dependencies:
       '@content-collections/core': 0.14.2(typescript@5.7.2)
       '@content-collections/integrations': 0.5.0(@content-collections/core@0.14.2(typescript@5.7.2))
-      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2)
+      next: 16.2.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2)
 
   '@csstools/selector-resolve-nested@1.1.0(postcss-selector-parser@6.1.2)':
     dependencies:
@@ -5904,7 +5904,7 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.10.0':
+  '@emnapi/runtime@1.11.3':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -6278,7 +6278,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.3
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -6392,7 +6392,7 @@ snapshots:
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.7.1
-      '@emnapi/runtime': 1.10.0
+      '@emnapi/runtime': 1.11.3
       '@tybys/wasm-util': 0.10.1
     optional: true
 
@@ -6403,7 +6403,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@next/env@16.2.6': {}
+  '@next/env@16.2.11': {}
 
   '@next/eslint-plugin-next@16.2.1':
     dependencies:
@@ -6416,28 +6416,28 @@ snapshots:
       '@mdx-js/loader': 3.1.1
       '@mdx-js/react': 3.1.1(@types/react@18.3.12)(react@19.0.0)
 
-  '@next/swc-darwin-arm64@16.2.6':
+  '@next/swc-darwin-arm64@16.2.11':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.6':
+  '@next/swc-darwin-x64@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.6':
+  '@next/swc-linux-arm64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.6':
+  '@next/swc-linux-arm64-musl@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.6':
+  '@next/swc-linux-x64-gnu@16.2.11':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.6':
+  '@next/swc-linux-x64-musl@16.2.11':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.6':
+  '@next/swc-win32-arm64-msvc@16.2.11':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.6':
+  '@next/swc-win32-x64-msvc@16.2.11':
     optional: true
 
   '@nodelib/fs.scandir@2.1.5':
@@ -8597,7 +8597,7 @@ snapshots:
       '@typescript-eslint/visitor-keys': 8.57.2
       debug: 4.4.3
       minimatch: 10.2.4
-      semver: 7.8.0
+      semver: 7.8.5
       tinyglobby: 0.2.15
       ts-api-utils: 2.5.0(typescript@5.7.2)
       typescript: 5.7.2
@@ -8884,7 +8884,7 @@ snapshots:
   browserslist@4.28.1:
     dependencies:
       baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001792
+      caniuse-lite: 1.0.30001806
       electron-to-chromium: 1.5.328
       node-releases: 2.0.36
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
@@ -8915,7 +8915,7 @@ snapshots:
 
   camelcase@8.0.0: {}
 
-  caniuse-lite@1.0.30001792: {}
+  caniuse-lite@1.0.30001806: {}
 
   ccount@2.0.1: {}
 
@@ -10085,7 +10085,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.8.0
+      semver: 7.8.5
 
   is-callable@1.2.7: {}
 
@@ -10914,7 +10914,7 @@ snapshots:
 
   nanoid@3.3.11: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.16: {}
 
   napi-build-utils@2.0.0: {}
 
@@ -10922,25 +10922,25 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2):
+  next@16.2.11(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(sass@1.94.2):
     dependencies:
-      '@next/env': 16.2.6
+      '@next/env': 16.2.11
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
-      caniuse-lite: 1.0.30001792
+      caniuse-lite: 1.0.30001806
       postcss: 8.4.31
       react: 19.0.0
       react-dom: 19.0.0(react@19.0.0)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.0.0)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.6
-      '@next/swc-darwin-x64': 16.2.6
-      '@next/swc-linux-arm64-gnu': 16.2.6
-      '@next/swc-linux-arm64-musl': 16.2.6
-      '@next/swc-linux-x64-gnu': 16.2.6
-      '@next/swc-linux-x64-musl': 16.2.6
-      '@next/swc-win32-arm64-msvc': 16.2.6
-      '@next/swc-win32-x64-msvc': 16.2.6
+      '@next/swc-darwin-arm64': 16.2.11
+      '@next/swc-darwin-x64': 16.2.11
+      '@next/swc-linux-arm64-gnu': 16.2.11
+      '@next/swc-linux-arm64-musl': 16.2.11
+      '@next/swc-linux-x64-gnu': 16.2.11
+      '@next/swc-linux-x64-musl': 16.2.11
+      '@next/swc-win32-arm64-msvc': 16.2.11
+      '@next/swc-win32-x64-msvc': 16.2.11
       '@opentelemetry/api': 1.9.0
       sass: 1.94.2
       sharp: 0.34.5
@@ -10954,7 +10954,7 @@ snapshots:
 
   node-abi@3.85.0:
     dependencies:
-      semver: 7.8.0
+      semver: 7.8.5
 
   node-addon-api@6.1.0: {}
 
@@ -11147,7 +11147,7 @@ snapshots:
 
   postcss@8.4.31:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.16
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -11764,7 +11764,7 @@ snapshots:
 
   semver@7.7.3: {}
 
-  semver@7.8.0: {}
+  semver@7.8.5: {}
 
   serialize-javascript@7.0.4: {}
 
@@ -11809,7 +11809,7 @@ snapshots:
     dependencies:
       '@img/colour': 1.1.0
       detect-libc: 2.1.2
-      semver: 7.8.0
+      semver: 7.8.5
     optionalDependencies:
       '@img/sharp-darwin-arm64': 0.34.5
       '@img/sharp-darwin-x64': 0.34.5

--- a/proxy.js
+++ b/proxy.js
@@ -73,6 +73,7 @@ const GONE_PATHS = [
   '/blog/some-post',
   '/2',
   '/mo',
+  '/**',
 ]
 
 const GONE_PREFIXES = ['/Users/']
@@ -129,6 +130,6 @@ export const config = {
      * - favicon.ico
      * - public assets (images, fonts, icons)
      */
-    '/((?!_next/static|_next/image|favicon.ico|images|fonts|icon).*)',
+    '/((?!_next/static|_next/image|favicon.ico|images|icon).*)',
   ],
 }

--- a/proxy.js
+++ b/proxy.js
@@ -1,9 +1,13 @@
 import { NextResponse } from 'next/server'
 
+import siteMetadata from '@/content/metadata'
+import { notFoundMarkdown, goneMarkdown } from '@/lib/agent/not-found'
+
 // Agent discovery resources advertised via RFC 8288 Link headers.
 const LINK_HEADER = [
   '</.well-known/api-catalog>; rel="api-catalog"; type="application/linkset+json"',
   '</.well-known/agent-skills/index.json>; rel="https://agentskills.io/rel/index"; type="application/json"',
+  '</openapi.json>; rel="service-desc"; type="application/json"',
   '</llms.txt>; rel="https://llmstxt.org/rel/llms"; type="text/plain"',
   '</feed.xml>; rel="alternate"; type="application/rss+xml"; title="RSS feed"',
   '</sitemap.xml>; rel="sitemap"; type="application/xml"',
@@ -11,6 +15,11 @@ const LINK_HEADER = [
 ].join(', ')
 
 const MARKDOWN_ACCEPT = /(^|,\s*)text\/markdown(\s*;|\s*,|\s*$)/i
+
+// Paths served from disk or by a route handler. They answer for themselves, so
+// negotiation must not touch them: `/.well-known/agent-skills/*/SKILL.md` is a
+// real file and would otherwise be swallowed by the markdown 404 below.
+const RESERVED_PREFIXES = ['/.well-known/', '/api/', '/_next/']
 
 const MARKDOWN_ROUTES = [
   { pattern: /^\/$/, target: () => '/api/content/home' },
@@ -36,10 +45,19 @@ function markdownTargetFor(pathname) {
   return null
 }
 
+// `Vary` is deliberately not set here. Next.js overwrites it on every page
+// response with its own RSC token list, so `Accept` has to be added at the CDN
+// for the negotiated paths — see the Vary rules in netlify.toml and
+// vercel.json. Markdown responses set their own `Vary` in the route handler.
 function withDiscoveryHeaders(response) {
   response.headers.append('Link', LINK_HEADER)
-  response.headers.set('Vary', 'Accept')
   return response
+}
+
+const MARKDOWN_HEADERS = {
+  'Content-Type': 'text/markdown; charset=utf-8',
+  'Cache-Control': 'no-store',
+  Vary: 'Accept, Accept-Encoding',
 }
 
 const STRIP_PARAMS = [
@@ -92,14 +110,18 @@ export function proxy(request) {
     return response
   }
 
-  if (GONE_PATHS.includes(pathname)) {
-    return respond(new NextResponse(null, { status: 410 }))
-  }
+  const isGone =
+    GONE_PATHS.includes(pathname) ||
+    GONE_PREFIXES.some((prefix) => pathname.startsWith(prefix))
 
-  for (const prefix of GONE_PREFIXES) {
-    if (pathname.startsWith(prefix)) {
-      return respond(new NextResponse(null, { status: 410 }))
-    }
+  if (isGone) {
+    // A bare 410 tells an agent nothing about where to go instead.
+    return respond(
+      new NextResponse(goneMarkdown(siteMetadata.siteUrl, pathname), {
+        status: 410,
+        headers: MARKDOWN_HEADERS,
+      })
+    )
   }
 
   const url = request.nextUrl.clone()
@@ -120,12 +142,31 @@ export function proxy(request) {
   const acceptsMarkdown = MARKDOWN_ACCEPT.test(
     request.headers.get('accept') || ''
   )
-  if (acceptsMarkdown || pathname.endsWith('.md')) {
+  const reserved = RESERVED_PREFIXES.some((prefix) =>
+    pathname.startsWith(prefix)
+  )
+  const wantsMarkdown =
+    (acceptsMarkdown || pathname.endsWith('.md')) && !reserved
+
+  if (wantsMarkdown) {
     const target = markdownTargetFor(pathname)
     if (target) {
       const rewriteUrl = request.nextUrl.clone()
       rewriteUrl.pathname = target
       return respond(withDiscoveryHeaders(NextResponse.rewrite(rewriteUrl)))
+    }
+
+    // A `.md` URL with no markdown representation never existed as a page, so
+    // answer in the format that was asked for rather than the HTML 404.
+    if (pathname.endsWith('.md')) {
+      return respond(
+        withDiscoveryHeaders(
+          new NextResponse(notFoundMarkdown(siteMetadata.siteUrl, pathname), {
+            status: 404,
+            headers: MARKDOWN_HEADERS,
+          })
+        )
+      )
     }
   }
 

--- a/proxy.js
+++ b/proxy.js
@@ -78,16 +78,27 @@ const GONE_PATHS = [
 
 const GONE_PREFIXES = ['/Users/']
 
+// Only the canonical host may be indexed. Archive subdomains, branch
+// deploys and previews stay crawlable so Google can see the noindex.
+const INDEXABLE_HOSTS = ['iamsteve.me', 'localhost']
+
 export function proxy(request) {
   const { pathname } = request.nextUrl
 
+  const respond = (response) => {
+    if (!INDEXABLE_HOSTS.includes(request.nextUrl.hostname)) {
+      response.headers.set('X-Robots-Tag', 'noindex')
+    }
+    return response
+  }
+
   if (GONE_PATHS.includes(pathname)) {
-    return new NextResponse(null, { status: 410 })
+    return respond(new NextResponse(null, { status: 410 }))
   }
 
   for (const prefix of GONE_PREFIXES) {
     if (pathname.startsWith(prefix)) {
-      return new NextResponse(null, { status: 410 })
+      return respond(new NextResponse(null, { status: 410 }))
     }
   }
 
@@ -102,7 +113,7 @@ export function proxy(request) {
   }
 
   if (stripped) {
-    return NextResponse.redirect(url, 301)
+    return respond(NextResponse.redirect(url, 301))
   }
 
   // Serve markdown when the agent asks for it via Accept header or .md suffix.
@@ -114,11 +125,11 @@ export function proxy(request) {
     if (target) {
       const rewriteUrl = request.nextUrl.clone()
       rewriteUrl.pathname = target
-      return withDiscoveryHeaders(NextResponse.rewrite(rewriteUrl))
+      return respond(withDiscoveryHeaders(NextResponse.rewrite(rewriteUrl)))
     }
   }
 
-  return withDiscoveryHeaders(NextResponse.next())
+  return respond(withDiscoveryHeaders(NextResponse.next()))
 }
 
 export const config = {

--- a/public/.well-known/agent-skills/get-article-as-markdown/SKILL.md
+++ b/public/.well-known/agent-skills/get-article-as-markdown/SKILL.md
@@ -20,14 +20,23 @@ Use this skill when you want the source markdown for an article on
 The site advertises markdown variants of HTML pages two ways:
 
 1. **Direct API** &mdash; request the markdown route directly.
+   - Homepage: `GET https://iamsteve.me/api/content/home`
    - Blog posts: `GET https://iamsteve.me/api/content/{slug}`
    - Notes: `GET https://iamsteve.me/api/content/notes/{slug}`
+   - Pages: `GET https://iamsteve.me/api/content/pages/{slug}`
+   - Collections: `GET https://iamsteve.me/api/content/collections/{slug}`
 2. **Content negotiation** &mdash; request the HTML URL with
-   `Accept: text/markdown` and the site responds with the markdown variant.
+   `Accept: text/markdown`, or append `.md` to it, and the site responds with
+   the markdown variant.
 
-The response uses `Content-Type: text/markdown; charset=utf-8` and includes
-YAML frontmatter with title, author, date, description, categories, and the
-canonical URL.
+The response uses `Content-Type: text/markdown; charset=utf-8` and sends
+`Vary: Accept, Accept-Encoding` so a shared cache cannot hand you the HTML
+variant by mistake. The body includes YAML frontmatter with title, author,
+date, description, categories, and the canonical URL.
+
+A slug that does not exist returns `404` with a markdown body listing the
+sitemap, [/llms.txt](https://iamsteve.me/llms.txt) and the other places to
+look, so a wrong guess still tells you where to go next.
 
 ## Examples
 
@@ -38,6 +47,9 @@ curl https://iamsteve.me/api/content/horizontal-scrolling-responsive-menu
 # Content negotiation
 curl -H "Accept: text/markdown" \
   https://iamsteve.me/blog/horizontal-scrolling-responsive-menu
+
+# Or the .md suffix
+curl https://iamsteve.me/blog/horizontal-scrolling-responsive-menu.md
 ```
 
 ## Discovery

--- a/public/.well-known/agent-skills/subscribe-newsletter/SKILL.md
+++ b/public/.well-known/agent-skills/subscribe-newsletter/SKILL.md
@@ -28,12 +28,34 @@ curl -X POST https://iamsteve.me/api/newsletter \
 
 ## Responses
 
-- `200 OK` with `{ "success": true }` &mdash; subscription created and
-  confirmation email sent.
-- `400 Bad Request` with `{ "error": "MEMBER_EXISTS_WITH_EMAIL_ADDRESS" }`
-  &mdash; the email is already on the list.
-- `400 Bad Request` with `{ "error": "Email is required" }` &mdash; the
-  request is missing the `email` field.
+`200 OK` returns `{ "success": true }` &mdash; the subscription was created and
+the confirmation email sent.
+
+Every failure returns the same JSON shape, so branch on `error.code` rather
+than on the message text.
+
+```json
+{
+  "error": {
+    "code": "MEMBER_EXISTS_WITH_EMAIL_ADDRESS",
+    "message": "That email address is already subscribed.",
+    "hint": "No action needed. Check the inbox for the confirmation email.",
+    "status": 400,
+    "documentation": "https://iamsteve.me/openapi.json"
+  }
+}
+```
+
+| Code                               | Status | Meaning                               |
+| ---------------------------------- | ------ | ------------------------------------- |
+| `EMAIL_REQUIRED`                   | 400    | The body is missing the `email` field |
+| `INVALID_JSON`                     | 400    | The body could not be parsed as JSON  |
+| `MEMBER_EXISTS_WITH_EMAIL_ADDRESS` | 400    | The address is already on the list    |
+| `SUBSCRIPTION_FAILED`              | 4xx    | The provider rejected the address     |
+| `NEWSLETTER_UNAVAILABLE`           | 500    | The provider could not be reached     |
+
+The full request and response schemas are published at
+[/openapi.json](https://iamsteve.me/openapi.json).
 
 ## Notes
 

--- a/scripts/validate-collection-links.js
+++ b/scripts/validate-collection-links.js
@@ -8,10 +8,21 @@ const pLimit = require('p-limit').default
 const COLLECTIONS_DIR = 'content/collections'
 const CACHE_FILE = '.link-validation-cache'
 const RESULTS_FILE = '.validation-results.json'
+const IGNORE_FILE = 'link-check-ignore.json'
 const CACHE_TTL_DAYS = 7
 const CONCURRENT_REQUESTS = 5
 const REQUEST_TIMEOUT_MS = 10000
 const MAX_RETRIES = 2
+
+// Query params that never change which page you land on
+const TRACKING_PARAMS =
+  /^(utm_|mc_(cid|eid)$|fbclid$|gclid$|igshid$|ref$|source$)/i
+
+// Many CDNs reject HEAD outright, so retry these with GET before believing them
+const RETRY_WITH_GET = new Set([403, 404, 405, 406, 409, 429, 501])
+
+// Responses that mean "a server answered, but refused to prove the page exists"
+const BOT_PROTECTION_CODES = new Set([401, 403, 406, 429, 503])
 
 // Browser-like headers for requests
 const REQUEST_HEADERS = {
@@ -40,6 +51,23 @@ function saveCache(cache) {
   fs.writeFileSync(CACHE_FILE, JSON.stringify(cache, null, 2))
 }
 
+// Load acknowledged links — URLs checked by hand that should be left alone
+function loadIgnoreList() {
+  if (!fs.existsSync(IGNORE_FILE)) return new Map()
+  try {
+    const { urls } = JSON.parse(fs.readFileSync(IGNORE_FILE, 'utf8'))
+    return new Map(
+      Object.entries(urls || {}).map(([url, reason]) => [
+        normaliseUrl(url),
+        reason,
+      ])
+    )
+  } catch (error) {
+    console.warn(`⚠️  Could not read ${IGNORE_FILE}: ${error.message}`)
+    return new Map()
+  }
+}
+
 // Check if cache entry is still valid
 function isCacheValid(entry) {
   if (!entry || !entry.timestamp) return false
@@ -47,43 +75,61 @@ function isCacheValid(entry) {
   return age < CACHE_TTL_DAYS * 24 * 60 * 60 * 1000
 }
 
-// Get domain key for duplicate detection
-function getDomainKey(url) {
+// Track how long a URL has held its current status, across runs. A link that
+// has been refused every week is stable; one that just changed is the news.
+function recordStatus(cache, url, status, statusCode) {
+  const previous = cache[url]
+  const now = Date.now()
+  const changed = !previous || previous.status !== status
+
+  cache[url] = {
+    status,
+    statusCode,
+    timestamp: now,
+    since: changed ? now : previous.since || previous.timestamp || now,
+    runs: changed ? 1 : (previous.runs || 1) + 1,
+  }
+
+  return cache[url]
+}
+
+// A bare domain link — for these a responding host answers most of the question
+function isHomepage(url) {
+  try {
+    return new URL(url).pathname.replace(/\/$/, '') === ''
+  } catch {
+    return false
+  }
+}
+
+// Normalise a URL so that two links to the same page produce the same key.
+// Collapses protocol, www, trailing slash, fragment and tracking params.
+function normaliseUrl(url) {
   try {
     const urlObj = new URL(url)
-    const domain = urlObj.hostname.replace('www.', '')
 
-    // Special handling for platforms with unique content per path
-    const platformsWithUniqueContent = [
-      'medium.com',
-      'github.com',
-      'youtube.com',
-      'twitter.com',
-      'x.com',
-      'linkedin.com',
-      'behance.net',
-      'dribbble.com',
-    ]
+    urlObj.protocol = 'https:'
+    urlObj.hostname = urlObj.hostname.replace(/^www\./, '').toLowerCase()
+    urlObj.hash = ''
 
-    // For content platforms, include path in key
-    if (platformsWithUniqueContent.some((p) => domain.includes(p))) {
-      return `${domain}${urlObj.pathname}`
+    for (const param of [...urlObj.searchParams.keys()]) {
+      if (TRACKING_PARAMS.test(param)) urlObj.searchParams.delete(param)
     }
+    urlObj.searchParams.sort()
 
-    // For regular sites, just use domain
-    return domain
+    return urlObj.toString().replace(/\/$/, '')
   } catch {
     return url // Fallback to full URL if parsing fails
   }
 }
 
-// Detect duplicate URLs across all collections
+// Detect links to the same page across all collections
 function detectDuplicates(allCollections) {
-  const urlMap = new Map() // domain/path -> [files]
+  const urlMap = new Map() // normalised url -> [files]
   const duplicates = []
 
   allCollections.forEach(({ file, url }) => {
-    const key = getDomainKey(url)
+    const key = normaliseUrl(url)
 
     if (!urlMap.has(key)) {
       urlMap.set(key, [])
@@ -91,11 +137,10 @@ function detectDuplicates(allCollections) {
     urlMap.get(key).push({ file, url })
   })
 
-  // Find duplicates
   for (const [key, files] of urlMap.entries()) {
     if (files.length > 1) {
       duplicates.push({
-        domain: key,
+        url: key,
         files: files,
         count: files.length,
       })
@@ -105,12 +150,32 @@ function detectDuplicates(allCollections) {
   return duplicates
 }
 
-// Categorize errors: 404 is definitely broken, everything else needs manual check
+// Categorize: 404/410 are dead, bot protection is unverifiable, rest needs a look
 function categorizeError(result) {
-  if (result.statusCode === 404) {
+  if (result.statusCode === 404 || result.statusCode === 410) {
     return { category: 'broken', priority: 'high', icon: '❌' }
   }
+  if (result.blocked) {
+    return { category: 'blocked', priority: 'none', icon: '🛡️' }
+  }
   return { category: 'needs_check', priority: 'low', icon: '⚠️' }
+}
+
+// Identify a refusal by bot protection rather than a missing page
+function isBotProtection(status, headers) {
+  if (!BOT_PROTECTION_CODES.has(status)) return false
+
+  const via = `${headers.get('server') || ''} ${
+    headers.get('cf-mitigated') || ''
+  } ${headers.get('x-powered-by') || ''}`.toLowerCase()
+
+  const vendor =
+    headers.has('cf-ray') ||
+    headers.has('x-datadome') ||
+    /cloudflare|akamai|datadome|sucuri|incapsula|imperva|perimeterx/.test(via)
+
+  // 401/403 from a known WAF, or any of these codes, means we simply can't tell
+  return vendor || status === 403 || status === 429 || status === 503
 }
 
 // Make a fetch request with timeout and browser-like headers
@@ -122,6 +187,10 @@ async function request(url, method = 'HEAD') {
     signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
   })
 
+  // Only the status line matters here. Releasing the body frees the socket
+  // straight away instead of holding it while a whole page arrives.
+  await response.body?.cancel().catch(() => {})
+
   if (response.status >= 200 && response.status < 400) {
     return { status: 'valid', statusCode: response.status }
   }
@@ -130,6 +199,7 @@ async function request(url, method = 'HEAD') {
     status: 'error',
     statusCode: response.status,
     error: `HTTP ${response.status}`,
+    blocked: isBotProtection(response.status, response.headers),
   }
 }
 
@@ -137,13 +207,15 @@ async function request(url, method = 'HEAD') {
 async function validateUrl(url, retries = MAX_RETRIES) {
   try {
     // Try HEAD first (faster)
-    const headResult = await request(url, 'HEAD')
-    if (headResult.status === 'valid') return headResult
+    let result = await request(url, 'HEAD')
+    if (result.status === 'valid') return result
 
-    // 405 Method Not Allowed — fall back to GET
-    if (headResult.statusCode === 405) {
+    // Plenty of servers and CDNs reject HEAD, so a GET is the honest answer
+    if (RETRY_WITH_GET.has(result.statusCode)) {
       try {
-        return await request(url, 'GET')
+        const getResult = await request(url, 'GET')
+        if (getResult.status === 'valid') return getResult
+        result = getResult
       } catch (getError) {
         if (retries > 0) {
           await new Promise((resolve) =>
@@ -162,7 +234,7 @@ async function validateUrl(url, retries = MAX_RETRIES) {
     // Retry on timeout, rate limit, or server error
     if (
       retries > 0 &&
-      (headResult.statusCode === 429 || headResult.statusCode >= 500)
+      (result.statusCode === 429 || result.statusCode >= 500)
     ) {
       await new Promise((resolve) =>
         setTimeout(resolve, 2000 * (MAX_RETRIES - retries + 1))
@@ -170,7 +242,7 @@ async function validateUrl(url, retries = MAX_RETRIES) {
       return validateUrl(url, retries - 1)
     }
 
-    return headResult
+    return result
   } catch (error) {
     const isTimeout =
       error.name === 'TimeoutError' || error.cause?.code === 'ETIMEDOUT'
@@ -220,15 +292,18 @@ function getFilesToCheck() {
 
 async function main() {
   const cache = loadCache()
+  const ignored = loadIgnoreList()
   const filesToCheck = getFilesToCheck()
 
   console.log(`Checking ${filesToCheck.length} collection files...`)
 
   const results = {
     valid: [],
-    broken: [], // 404 errors only
-    needs_check: [], // All other errors
+    broken: [], // 404/410 — the page is genuinely gone
+    blocked: [], // Refused by bot protection — unverifiable, not actionable
+    needs_check: [], // Everything else
     duplicates: [],
+    acknowledged: [], // Listed in link-check-ignore.json
     skipped: [],
   }
 
@@ -247,8 +322,23 @@ async function main() {
       const url = data.url
       const filename = path.basename(file)
 
-      // Check cache
-      if (cache[url] && isCacheValid(cache[url])) {
+      // Acknowledged by hand — leave it alone
+      if (ignored.has(normaliseUrl(url))) {
+        console.log(`🔕 ${filename} (acknowledged)`)
+        results.acknowledged.push({
+          file: filename,
+          url,
+          reason: ignored.get(normaliseUrl(url)),
+        })
+        return
+      }
+
+      // Check cache — only a known-good result lets us skip the request
+      if (
+        cache[url] &&
+        cache[url].status === 'valid' &&
+        isCacheValid(cache[url])
+      ) {
         console.log(`✓ ${filename} (cached)`)
         results.valid.push({ file: filename, url, cached: true })
         return
@@ -261,29 +351,40 @@ async function main() {
       if (result.status === 'valid') {
         console.log(`✓ ${filename}`)
         results.valid.push({ file: filename, url })
-        cache[url] = { status: 'valid', timestamp: Date.now() }
+        recordStatus(cache, url, 'valid', result.statusCode)
       } else {
         const errorCategory = categorizeError(result)
+
+        // Track the raw category so a streak keeps counting across runs
+        const history = recordStatus(
+          cache,
+          url,
+          errorCategory.category,
+          result.statusCode
+        )
+
+        // A domain that repeatedly fails to resolve has genuinely gone, but one
+        // transient DNS blip in CI should not condemn a live site
+        const deadDomain = result.code === 'ENOTFOUND' && history.runs >= 2
+        const category = deadDomain ? 'broken' : errorCategory.category
+
         console.log(
-          `${errorCategory.icon} ${filename}: ${
+          `${deadDomain ? '❌' : errorCategory.icon} ${filename}: ${
             result.error || result.statusCode
           }`
         )
 
-        const errorInfo = {
+        results[category].push({
           file: filename,
           url,
           error: result.error,
           statusCode: result.statusCode,
           code: result.code,
-        }
-
-        // Categorize: 404s are definitely broken, everything else needs manual check
-        if (errorCategory.category === 'broken') {
-          results.broken.push(errorInfo)
-        } else {
-          results.needs_check.push(errorInfo)
-        }
+          since: history.since,
+          runs: history.runs,
+          changed: history.runs === 1,
+          homepage: isHomepage(url),
+        })
       }
     })
   )
@@ -306,48 +407,82 @@ async function main() {
   // Save cache and results
   saveCache(cache)
 
+  const failures = [
+    ...results.broken,
+    ...results.blocked,
+    ...results.needs_check,
+  ]
+  const changedCount = failures.filter((r) => r.changed).length
+
   const summary = `
 **Summary:**
 - ✅ Valid: ${results.valid.length}
 - ❌ Broken (High Priority): ${results.broken.length}
 - ⚠️ Needs Check (Low Priority): ${results.needs_check.length}
+- 🛡️ Blocked by bot protection: ${results.blocked.length}
+- 🆕 Changed since last run: ${changedCount}
 - 🔗 Duplicate URLs: ${results.duplicates.length}
+- 🔕 Acknowledged: ${results.acknowledged.length}
   `.trim()
 
   let details = ''
 
-  // Broken links (404s only - high priority)
+  const errorTable = (rows) => {
+    let table =
+      '| File | URL | Error | Since |\n|------|-----|-------|-------|\n'
+    rows.forEach(({ file, url, error, statusCode, code, since, runs }) => {
+      const errorMsg = statusCode
+        ? `HTTP ${statusCode}`
+        : code || error || 'Unknown'
+      const seen =
+        runs > 1
+          ? `${new Date(since).toISOString().slice(0, 10)} (${runs} runs)`
+          : '🆕 new'
+      table += `| ${file} | ${url} | ${errorMsg} | ${seen} |\n`
+    })
+    return table
+  }
+
+  // Broken links (404/410 confirmed by GET - high priority)
   if (results.broken.length > 0) {
     details += '\n\n### ❌ Broken Links (Definitely Dead - High Priority)\n\n'
-    details += '| File | URL | Error |\n'
-    details += '|------|-----|-------|\n'
-    results.broken.forEach(({ file, url, error, statusCode, code }) => {
-      const errorMsg = statusCode
-        ? `HTTP ${statusCode}`
-        : code || error || 'Unknown'
-      details += `| ${file} | ${url} | ${errorMsg} |\n`
-    })
+    details += errorTable(results.broken)
   }
 
-  // Needs manual check (everything else - low priority, likely bot blocks)
+  // Needs manual check (timeouts, DNS failures, server errors)
   if (results.needs_check.length > 0) {
-    details +=
-      '\n\n### ⚠️ Needs Manual Check (Likely Bot Protection - Low Priority)\n\n'
-    details += '| File | URL | Error |\n'
-    details += '|------|-----|-------|\n'
-    results.needs_check.forEach(({ file, url, error, statusCode, code }) => {
-      const errorMsg = statusCode
-        ? `HTTP ${statusCode}`
-        : code || error || 'Unknown'
-      details += `| ${file} | ${url} | ${errorMsg} |\n`
-    })
+    details += '\n\n### ⚠️ Needs Manual Check (Low Priority)\n\n'
+    details += errorTable(results.needs_check)
   }
 
-  // Duplicate URLs
+  // Blocked by bot protection — split by how much doubt there actually is.
+  // A refusal still proves DNS, TLS and a live server, so for a bare domain
+  // there is little left to doubt. Only a deep link can still have rotted.
+  if (results.blocked.length > 0) {
+    const deepLinks = results.blocked.filter((r) => !r.homepage)
+    const homepages = results.blocked.filter((r) => r.homepage)
+
+    if (deepLinks.length > 0) {
+      details += `\n\n### 🛡️ Blocked deep links (${deepLinks.length})\n\n`
+      details +=
+        'The host is answering, but these point at a specific page that could not be confirmed. Worth opening by hand.\n\n'
+      details += errorTable(deepLinks)
+    }
+
+    if (homepages.length > 0) {
+      details += '\n\n<details>\n<summary>🛡️ Blocked homepages '
+      details += `(${homepages.length}) — host responding, so the site is alive</summary>\n\n`
+      details += errorTable(homepages)
+      details += `\nAdd any of these to \`${IGNORE_FILE}\` to stop them appearing here.\n`
+      details += '\n</details>\n'
+    }
+  }
+
+  // Duplicate URLs — two files pointing at the same page
   if (results.duplicates.length > 0) {
     details += '\n\n### 🔗 Duplicate URLs Found\n\n'
-    results.duplicates.forEach(({ domain, files, count }) => {
-      details += `**${domain}** (${count} files)\n`
+    results.duplicates.forEach(({ url, files, count }) => {
+      details += `**${url}** (${count} files)\n`
       files.forEach(({ file, url }) => {
         details += `  - \`${file}\` → ${url}\n`
       })
@@ -372,8 +507,13 @@ async function main() {
   console.log('\n' + summary)
   console.log(details)
 
-  // Set output for GitHub Actions
-  console.log(`::set-output name=broken_count::${results.broken.length}`)
+  // Set output for GitHub Actions (::set-output is no longer honoured)
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(
+      process.env.GITHUB_OUTPUT,
+      `broken_count=${results.broken.length}\n`
+    )
+  }
 
   // Exit with non-zero if broken links found (optional - comment out to make non-blocking)
   // process.exit(results.broken.length > 0 ? 1 : 0);
@@ -393,8 +533,10 @@ main().catch((error) => {
         results: {
           valid: [],
           broken: [],
+          blocked: [],
           needs_check: [],
           duplicates: [],
+          acknowledged: [],
           skipped: [],
         },
       },
@@ -402,4 +544,9 @@ main().catch((error) => {
       2
     )
   )
+
+  // -1 means "unknown", so a crash neither files an issue nor closes an open one
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, 'broken_count=-1\n')
+  }
 })

--- a/scripts/validate-collection-links.js
+++ b/scripts/validate-collection-links.js
@@ -281,6 +281,7 @@ function getFilesToCheck() {
     return output
       .split('\n')
       .filter((f) => f.startsWith(COLLECTIONS_DIR) && f.endsWith('.md'))
+      .filter((f) => fs.existsSync(f)) // a removed collection has nothing to check
   } catch {
     // Fallback: check all if git diff fails
     return fs

--- a/scripts/verify-agent-endpoints.js
+++ b/scripts/verify-agent-endpoints.js
@@ -1,0 +1,327 @@
+#!/usr/bin/env node
+/**
+ * Checks the endpoints and machine-readable files agents rely on, against a
+ * running server. Defaults to the local production server:
+ *
+ *   pnpm build && pnpm serve &
+ *   node scripts/verify-agent-endpoints.js
+ *   node scripts/verify-agent-endpoints.js https://iamsteve.me
+ */
+const base = (process.argv[2] || 'http://localhost:3000').replace(/\/$/, '')
+
+let failures = 0
+
+function report(name, problems) {
+  if (problems.length === 0) {
+    console.log(`  ok   ${name}`)
+    return
+  }
+  failures += 1
+  console.log(`  FAIL ${name}`)
+  for (const problem of problems) console.log(`       ${problem}`)
+}
+
+async function check(name, path, expect, options = {}) {
+  let response
+  let body
+  try {
+    response = await fetch(`${base}${path}`, { redirect: 'follow', ...options })
+    body = await response.text()
+  } catch (error) {
+    report(name, [`request failed: ${error.message}`])
+    return null
+  }
+
+  const problems = []
+  const type = response.headers.get('content-type') || ''
+  const vary = response.headers.get('vary') || ''
+
+  if (expect.status && response.status !== expect.status) {
+    problems.push(`expected ${expect.status}, got ${response.status}`)
+  }
+  if (expect.type && !type.includes(expect.type)) {
+    problems.push(`expected ${expect.type}, got "${type}"`)
+  }
+  if (
+    expect.varyIncludes &&
+    !vary.toLowerCase().includes(expect.varyIncludes)
+  ) {
+    problems.push(`Vary is missing ${expect.varyIncludes}, got "${vary}"`)
+  }
+  for (const fragment of expect.contains || []) {
+    if (!body.includes(fragment)) problems.push(`body is missing "${fragment}"`)
+  }
+  if (expect.minLength && body.length < expect.minLength) {
+    problems.push(`body is ${body.length} bytes, wanted ${expect.minLength}`)
+  }
+  if (expect.json) {
+    try {
+      const problem = expect.json(JSON.parse(body))
+      if (problem) problems.push(problem)
+    } catch (error) {
+      problems.push(`invalid JSON: ${error.message}`)
+    }
+  }
+  if (expect.body) {
+    const problem = expect.body(body, response)
+    if (problem) problems.push(problem)
+  }
+
+  report(name, problems)
+  return body
+}
+
+const markdown = { headers: { Accept: 'text/markdown' } }
+
+function textOf(html) {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/g, '')
+    .replace(/<style[\s\S]*?<\/style>/g, '')
+    .replace(/<[^>]+>/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+async function main() {
+  console.log(`Verifying ${base}\n`)
+
+  const llms = await fetch(`${base}/llms.txt`).then((response) =>
+    response.ok ? response.text() : ''
+  )
+  const post = llms.match(/\/api\/content\/([a-z0-9-]+)/)?.[1]
+  const sitemap = await fetch(`${base}/sitemap.xml`).then((response) =>
+    response.ok ? response.text() : ''
+  )
+  const note = sitemap.match(/\/notes\/([a-z0-9-]+)</)?.[1]
+  const collectionsIndex = await fetch(`${base}/collections`).then((response) =>
+    response.ok ? response.text() : ''
+  )
+  const collection = collectionsIndex.match(
+    /href="\/collections\/([a-z0-9-]+)"/
+  )?.[1]
+
+  console.log('Content without JavaScript')
+  await check('homepage renders server-side', '/', {
+    status: 200,
+    type: 'text/html',
+    body: (html) => {
+      const text = textOf(html)
+      if (text.length < 500) return `only ${text.length} chars of text`
+      if (!/<h1[\s>]/.test(html)) return 'no h1 in the raw HTML'
+      if (!/<h2[\s>]/.test(html)) return 'no h2 in the raw HTML'
+      if (!/<h3[\s>]/.test(html)) return 'flat heading structure, no h3'
+      return null
+    },
+  })
+
+  console.log('\nMarkdown content negotiation')
+  await check(
+    'homepage as markdown',
+    '/',
+    { status: 200, type: 'text/markdown', varyIncludes: 'accept' },
+    markdown
+  )
+  if (post) {
+    await check(
+      'article as markdown',
+      `/blog/${post}`,
+      {
+        status: 200,
+        type: 'text/markdown',
+        varyIncludes: 'accept',
+        contains: ['---'],
+      },
+      markdown
+    )
+    await check('article via the .md suffix', `/blog/${post}.md`, {
+      status: 200,
+      type: 'text/markdown',
+      varyIncludes: 'accept',
+    })
+    await check('article still serves HTML to browsers', `/blog/${post}`, {
+      status: 200,
+      type: 'text/html',
+    })
+  }
+  if (note) {
+    await check(
+      'note as markdown',
+      `/notes/${note}`,
+      { status: 200, type: 'text/markdown', varyIncludes: 'accept' },
+      markdown
+    )
+  }
+  if (collection) {
+    await check(
+      'collection listing as markdown',
+      `/collections/${collection}`,
+      {
+        status: 200,
+        type: 'text/markdown',
+        varyIncludes: 'accept',
+        contains: ['## Other collections'],
+      },
+      markdown
+    )
+  }
+  for (const page of ['/about', '/uses']) {
+    await check(
+      `${page} as markdown`,
+      page,
+      { status: 200, type: 'text/markdown', varyIncludes: 'accept' },
+      markdown
+    )
+  }
+
+  console.log('\nAgent-friendly 404s')
+  await check(
+    'unknown path returns a real 404',
+    '/some-path-that-does-not-exist',
+    {
+      status: 404,
+      type: 'text/html',
+      body: (html) => {
+        const text = textOf(html)
+        if (text.length < 200) return `404 body has only ${text.length} chars`
+        for (const href of ['/sitemap.xml', '/llms.txt', '/openapi.json']) {
+          if (!html.includes(`href="${href}"`))
+            return `404 body does not link ${href}`
+        }
+        return null
+      },
+    }
+  )
+  await check('unknown .md path answers in markdown', '/no-such-page.md', {
+    status: 404,
+    type: 'text/markdown',
+    varyIncludes: 'accept',
+    contains: ['# 404 Not Found', '/llms.txt', '/sitemap.xml'],
+  })
+  await check(
+    'unknown article slug answers in markdown',
+    '/api/content/no-such-post',
+    {
+      status: 404,
+      type: 'text/markdown',
+      contains: ['# 404 Not Found'],
+    }
+  )
+  await check('removed URLs answer 410 with a way forward', '/portfolio', {
+    status: 410,
+    type: 'text/markdown',
+    contains: ['# 410 Gone', '/llms.txt'],
+  })
+
+  console.log('\nOpenAPI')
+  await check('openapi.json', '/openapi.json', {
+    status: 200,
+    type: 'application/json',
+    json: (spec) => {
+      if (!spec.openapi?.startsWith('3.')) return `openapi is "${spec.openapi}"`
+      if (!spec.paths || Object.keys(spec.paths).length === 0) return 'no paths'
+      if (!spec.components?.schemas?.Error) return 'no Error schema'
+      return null
+    },
+  })
+
+  console.log('\nJSON error responses')
+  await check('unknown API path', '/api/does-not-exist', {
+    status: 404,
+    type: 'application/json',
+    json: ({ error }) =>
+      error?.code && error?.message && error?.hint
+        ? null
+        : 'error is missing code, message or hint',
+  })
+  await check(
+    'newsletter rejects a body with no email',
+    '/api/newsletter',
+    {
+      status: 400,
+      type: 'application/json',
+      json: ({ error }) =>
+        error?.code === 'EMAIL_REQUIRED'
+          ? null
+          : `unexpected code ${error?.code}`,
+    },
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    }
+  )
+  await check(
+    'newsletter rejects malformed JSON',
+    '/api/newsletter',
+    {
+      status: 400,
+      type: 'application/json',
+      json: ({ error }) =>
+        error?.code === 'INVALID_JSON'
+          ? null
+          : `unexpected code ${error?.code}`,
+    },
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: 'not json',
+    }
+  )
+
+  console.log('\nDiscovery')
+  await check('llms.txt', '/llms.txt', {
+    status: 200,
+    type: 'text/plain',
+    contains: ['/openapi.json'],
+  })
+  await check('feed.xml', '/feed.xml', { status: 200, type: 'xml' })
+  await check('sitemap.xml', '/sitemap.xml', { status: 200, type: 'xml' })
+  await check('robots.txt', '/robots.txt', {
+    status: 200,
+    type: 'text/plain',
+    contains: ['Sitemap'],
+  })
+  await check('api-catalog', '/.well-known/api-catalog', {
+    status: 200,
+    type: 'linkset+json',
+    json: (linkset) =>
+      JSON.stringify(linkset).includes('/openapi.json')
+        ? null
+        : 'the catalog does not point at the OpenAPI description',
+  })
+  const skills = await check(
+    'agent-skills index',
+    '/.well-known/agent-skills/index.json',
+    {
+      status: 200,
+      type: 'application/json',
+      json: (index) => (index.skills?.length ? null : 'no skills listed'),
+    }
+  )
+  for (const skill of JSON.parse(skills || '{"skills":[]}').skills) {
+    await check(`skill ${skill.name}`, new URL(skill.url).pathname, {
+      status: 200,
+      type: 'text/markdown',
+      minLength: 200,
+      contains: [`name: ${skill.name}`],
+    })
+  }
+  await check('Link header advertises the API description', '/', {
+    status: 200,
+    body: (_body, response) => {
+      const link = response.headers.get('link') || ''
+      return link.includes('rel="service-desc"')
+        ? null
+        : `Link header has no service-desc: "${link}"`
+    },
+  })
+
+  console.log(
+    failures === 0
+      ? '\nAll checks passed'
+      : `\n${failures} check${failures === 1 ? '' : 's'} failed`
+  )
+  process.exit(failures === 0 ? 0 : 1)
+}
+
+main()

--- a/tests/agent-recovery.test.js
+++ b/tests/agent-recovery.test.js
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  recoveryLinks,
+  notFoundMarkdown,
+  goneMarkdown,
+} from '@/lib/agent/not-found'
+
+const origin = 'https://iamsteve.me'
+
+test('recovery links are root-relative and described', () => {
+  for (const link of recoveryLinks) {
+    assert.ok(link.href.startsWith('/'), `${link.href} is not root-relative`)
+    assert.ok(link.title.length > 0)
+    assert.ok(link.description.length > 0)
+  }
+})
+
+test('recovery links cover the indexes an agent needs', () => {
+  const hrefs = recoveryLinks.map((link) => link.href)
+  for (const href of [
+    '/',
+    '/blog',
+    '/sitemap.xml',
+    '/llms.txt',
+    '/openapi.json',
+    '/.well-known/api-catalog',
+  ]) {
+    assert.ok(hrefs.includes(href), `${href} is missing from the 404 body`)
+  }
+})
+
+test('the 404 body names the path and links every index absolutely', () => {
+  const body = notFoundMarkdown(origin, '/no-such-page')
+
+  assert.match(body, /^---\n/)
+  assert.match(body, /status: 404/)
+  assert.match(body, /url: https:\/\/iamsteve\.me\/no-such-page/)
+  assert.match(body, /^# 404 Not Found$/m)
+  assert.match(body, /`\/no-such-page`/)
+  assert.match(body, /^## Where to look next$/m)
+
+  for (const link of recoveryLinks) {
+    assert.ok(
+      body.includes(`(${origin}${link.href})`),
+      `${link.href} is not linked absolutely`
+    )
+  }
+})
+
+test('the 404 body explains how to ask for markdown', () => {
+  const body = notFoundMarkdown(origin, '/no-such-page')
+
+  assert.match(body, /Accept: text\/markdown/)
+  assert.match(body, /\.md/)
+  assert.match(body, /\/api\/content\/\{slug\}/)
+  assert.match(body, /\/api\/content\/notes\/\{slug\}/)
+  assert.match(body, /\/api\/content\/pages\/\{slug\}/)
+  assert.match(body, /\/api\/content\/collections\/\{slug\}/)
+})
+
+test('the 410 body tells an agent to stop asking', () => {
+  const body = goneMarkdown(origin, '/portfolio')
+
+  assert.match(body, /status: 410/)
+  assert.match(body, /^# 410 Gone$/m)
+  assert.match(body, /Do not retry/)
+  assert.match(body, /^## Where to look next$/m)
+})
+
+test('a body long enough to be worth parsing', () => {
+  assert.ok(notFoundMarkdown(origin, '/x').length > 500)
+})

--- a/tests/alias-hook.mjs
+++ b/tests/alias-hook.mjs
@@ -1,0 +1,31 @@
+import { existsSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+
+const root = new URL('../', import.meta.url)
+
+/**
+ * Lets the test runner import the same modules the bundler does: resolves the
+ * `@/` alias from jsconfig.json, and adds the file extension Node insists on
+ * but a bundler infers.
+ */
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier.startsWith('@/')) {
+    const base = new URL(specifier.slice(2), root)
+    const candidates = [
+      base,
+      new URL(`${base.href}.js`),
+      new URL(`${base.href}/index.js`),
+    ]
+    const match = candidates.find((url) => existsSync(fileURLToPath(url)))
+    return nextResolve((match ?? base).href, context)
+  }
+
+  try {
+    return await nextResolve(specifier, context)
+  } catch (error) {
+    if (error.code !== 'ERR_MODULE_NOT_FOUND' || /\.[a-z]+$/.test(specifier)) {
+      throw error
+    }
+    return nextResolve(`${specifier}.js`, context)
+  }
+}

--- a/tests/api-errors.test.js
+++ b/tests/api-errors.test.js
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { apiError } from '@/lib/agent/errors'
+
+test('an error carries a code, a message, a hint and its status', async () => {
+  const response = apiError({
+    status: 400,
+    code: 'EMAIL_REQUIRED',
+    message: 'An email address is required to subscribe.',
+    hint: 'Include an "email" field in the JSON body.',
+  })
+
+  assert.equal(response.status, 400)
+  assert.equal(
+    response.headers.get('content-type'),
+    'application/json; charset=utf-8'
+  )
+  assert.equal(response.headers.get('cache-control'), 'no-store')
+
+  const { error } = await response.json()
+
+  assert.equal(error.code, 'EMAIL_REQUIRED')
+  assert.equal(error.message, 'An email address is required to subscribe.')
+  assert.equal(error.hint, 'Include an "email" field in the JSON body.')
+  assert.equal(error.status, 400)
+  assert.equal(error.documentation, 'https://iamsteve.me/openapi.json')
+})
+
+test('extra headers are merged, not dropped', () => {
+  const response = apiError({
+    status: 404,
+    code: 'NOT_FOUND',
+    message: 'Nothing here.',
+    hint: 'Read the OpenAPI description.',
+    headers: { 'Access-Control-Allow-Origin': '*' },
+  })
+
+  assert.equal(response.headers.get('access-control-allow-origin'), '*')
+  assert.equal(
+    response.headers.get('content-type'),
+    'application/json; charset=utf-8'
+  )
+})

--- a/tests/markdown-headers.test.js
+++ b/tests/markdown-headers.test.js
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import {
+  MARKDOWN_VARY,
+  markdownHeaders,
+  markdownNotFound,
+} from '@/lib/agent/markdown'
+
+test('markdown responses vary on Accept so caches keep the variants apart', () => {
+  assert.equal(MARKDOWN_VARY, 'Accept, Accept-Encoding')
+  assert.equal(markdownHeaders.Vary, MARKDOWN_VARY)
+  assert.equal(markdownHeaders['Content-Type'], 'text/markdown; charset=utf-8')
+})
+
+test('a missing slug answers 404 in markdown, not HTML', async () => {
+  const response = markdownNotFound('/blog/no-such-post')
+
+  assert.equal(response.status, 404)
+  assert.equal(
+    response.headers.get('content-type'),
+    'text/markdown; charset=utf-8'
+  )
+  assert.equal(response.headers.get('vary'), 'Accept, Accept-Encoding')
+  assert.equal(response.headers.get('cache-control'), 'no-store')
+
+  const body = await response.text()
+  assert.match(body, /# 404 Not Found/)
+  assert.match(body, /`\/blog\/no-such-post`/)
+  assert.match(body, /https:\/\/iamsteve\.me\/llms\.txt/)
+})

--- a/tests/openapi.test.js
+++ b/tests/openapi.test.js
@@ -1,0 +1,138 @@
+import assert from 'node:assert/strict'
+import { readdirSync, statSync } from 'node:fs'
+import path from 'node:path'
+import { test } from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+import { GET } from '@/app/openapi.json/route'
+
+const root = fileURLToPath(new URL('../', import.meta.url))
+const spec = await (await GET()).json()
+
+/** Every route.js under app/api, as the path an agent would call. */
+function apiRoutesOnDisk(dir = path.join(root, 'app', 'api'), prefix = '/api') {
+  const routes = []
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (entry === 'route.js') {
+      routes.push(prefix)
+    } else if (statSync(full).isDirectory()) {
+      const segment = entry
+        .replace(/^\[\.\.\.(.+)\]$/, '{...$1}')
+        .replace(/^\[(.+)\]$/, '{$1}')
+      routes.push(...apiRoutesOnDisk(full, `${prefix}/${segment}`))
+    }
+  }
+  return routes
+}
+
+test('the document declares itself as OpenAPI 3.1 for this site', () => {
+  assert.equal(spec.openapi, '3.1.0')
+  assert.equal(spec.info.title, 'iamsteve.me')
+  assert.ok(spec.info.version)
+  assert.deepEqual(
+    spec.servers.map((server) => server.url),
+    ['https://iamsteve.me']
+  )
+})
+
+test('the response is served as JSON an agent can fetch cross-origin', async () => {
+  const response = await GET()
+
+  assert.equal(
+    response.headers.get('content-type'),
+    'application/json; charset=utf-8'
+  )
+  assert.equal(response.headers.get('access-control-allow-origin'), '*')
+})
+
+test('every operation is addressable and documented', () => {
+  const operationIds = new Set()
+
+  for (const [route, methods] of Object.entries(spec.paths)) {
+    assert.ok(route.startsWith('/'), `${route} is not root-relative`)
+
+    for (const [method, operation] of Object.entries(methods)) {
+      const where = `${method.toUpperCase()} ${route}`
+      assert.ok(operation.operationId, `${where} has no operationId`)
+      assert.ok(operation.summary, `${where} has no summary`)
+      assert.ok(
+        Object.keys(operation.responses ?? {}).length > 0,
+        `${where} documents no responses`
+      )
+      assert.ok(
+        !operationIds.has(operation.operationId),
+        `${operation.operationId} is used twice`
+      )
+      operationIds.add(operation.operationId)
+    }
+  }
+})
+
+test('every path parameter is declared', () => {
+  for (const [route, methods] of Object.entries(spec.paths)) {
+    const templated = [...route.matchAll(/\{(\w+)\}/g)].map((match) => match[1])
+
+    for (const [method, operation] of Object.entries(methods)) {
+      const declared = (operation.parameters ?? [])
+        .filter((parameter) => parameter.in === 'path')
+        .map((parameter) => parameter.name)
+
+      assert.deepEqual(
+        declared.sort(),
+        templated.sort(),
+        `${method.toUpperCase()} ${route} declares the wrong path parameters`
+      )
+    }
+  }
+})
+
+test('every $ref resolves', () => {
+  const refs = [...JSON.stringify(spec).matchAll(/"\$ref":"([^"]+)"/g)].map(
+    (match) => match[1]
+  )
+
+  assert.ok(refs.length > 0)
+
+  for (const ref of refs) {
+    const resolved = ref
+      .replace(/^#\//, '')
+      .split('/')
+      .reduce((node, key) => node?.[key], spec)
+    assert.ok(resolved, `${ref} does not resolve`)
+  }
+})
+
+test('the error schema is the one the API actually returns', () => {
+  const error = spec.components.schemas.Error.properties.error
+
+  assert.deepEqual(error.required.sort(), ['code', 'hint', 'message', 'status'])
+  for (const key of ['code', 'message', 'hint', 'status', 'documentation']) {
+    assert.ok(error.properties[key], `the error schema is missing ${key}`)
+  }
+})
+
+test('the documented API surface matches the routes that exist', () => {
+  const onDisk = apiRoutesOnDisk()
+    // The catch-all only exists to answer unknown paths in JSON.
+    .filter((route) => !route.includes('{...'))
+    .sort()
+  const documented = Object.keys(spec.paths)
+    .filter((route) => route.startsWith('/api/'))
+    .sort()
+
+  assert.deepEqual(documented, onDisk)
+})
+
+test('the discovery documents are described too', () => {
+  for (const route of [
+    '/llms.txt',
+    '/feed.xml',
+    '/sitemap.xml',
+    '/openapi.json',
+    '/.well-known/api-catalog',
+    '/.well-known/agent-skills/index.json',
+  ]) {
+    assert.ok(spec.paths[route], `${route} is not described`)
+  }
+})

--- a/tests/proxy.test.js
+++ b/tests/proxy.test.js
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict'
+import { test } from 'node:test'
+
+import { NextRequest } from 'next/server'
+
+import { proxy } from '@/proxy'
+
+function request(url, headers = {}) {
+  return proxy(new NextRequest(url, { headers }))
+}
+
+const markdown = { accept: 'text/markdown' }
+
+test('markdown negotiation rewrites every content namespace', () => {
+  const cases = [
+    ['https://iamsteve.me/', '/api/content/home'],
+    [
+      'https://iamsteve.me/blog/kerning-vs-tracking',
+      '/api/content/kerning-vs-tracking',
+    ],
+    ['https://iamsteve.me/notes/a-note', '/api/content/notes/a-note'],
+    [
+      'https://iamsteve.me/collections/0to255',
+      '/api/content/collections/0to255',
+    ],
+    ['https://iamsteve.me/about', '/api/content/pages/about'],
+    ['https://iamsteve.me/uses', '/api/content/pages/uses'],
+  ]
+
+  for (const [url, target] of cases) {
+    const rewrite = request(url, markdown).headers.get('x-middleware-rewrite')
+    assert.equal(
+      new URL(rewrite).pathname,
+      target,
+      `${url} rewrote to ${rewrite}`
+    )
+  }
+})
+
+test('the .md suffix negotiates without an Accept header', () => {
+  const rewrite = request(
+    'https://iamsteve.me/blog/kerning-vs-tracking.md'
+  ).headers.get('x-middleware-rewrite')
+
+  assert.equal(new URL(rewrite).pathname, '/api/content/kerning-vs-tracking')
+})
+
+test('a negotiated rewrite still advertises the discovery links', () => {
+  const response = request('https://iamsteve.me/', markdown)
+
+  assert.match(response.headers.get('link'), /rel="service-desc"/)
+  assert.match(
+    response.headers.get('link'),
+    /rel="https:\/\/llmstxt\.org\/rel\/llms"/
+  )
+})
+
+test('markdown is only served when it is actually asked for', () => {
+  for (const accept of [
+    'text/html,application/xhtml+xml',
+    'application/json',
+    'text/markdownish',
+    '*/*',
+  ]) {
+    const response = request('https://iamsteve.me/blog/a-post', { accept })
+    assert.equal(
+      response.headers.get('x-middleware-rewrite'),
+      null,
+      `"${accept}" should not negotiate markdown`
+    )
+  }
+})
+
+test('markdown wins when a browser-style Accept list includes it', () => {
+  const rewrite = request('https://iamsteve.me/blog/a-post', {
+    accept: 'text/html, text/markdown;q=0.9',
+  }).headers.get('x-middleware-rewrite')
+
+  assert.equal(new URL(rewrite).pathname, '/api/content/a-post')
+})
+
+test('a .md URL with no markdown representation answers in markdown', async () => {
+  const response = request('https://iamsteve.me/nothing-here.md')
+
+  assert.equal(response.status, 404)
+  assert.equal(
+    response.headers.get('content-type'),
+    'text/markdown; charset=utf-8'
+  )
+  assert.equal(response.headers.get('vary'), 'Accept, Accept-Encoding')
+  assert.match(await response.text(), /# 404 Not Found/)
+})
+
+test('removed URLs answer 410 with somewhere else to go', async () => {
+  const response = request('https://iamsteve.me/portfolio')
+
+  assert.equal(response.status, 410)
+  assert.equal(
+    response.headers.get('content-type'),
+    'text/markdown; charset=utf-8'
+  )
+
+  const body = await response.text()
+  assert.match(body, /# 410 Gone/)
+  assert.match(body, /\/llms\.txt/)
+})
+
+test('removed prefixes answer 410 too', () => {
+  assert.equal(request('https://iamsteve.me/Users/steve/secret').status, 410)
+})
+
+test('discovery links advertise the OpenAPI description', () => {
+  const link = request('https://iamsteve.me/blog/a-post').headers.get('link')
+
+  assert.match(link, /<\/openapi\.json>; rel="service-desc"/)
+  assert.match(link, /rel="api-catalog"/)
+  assert.match(link, /rel="sitemap"/)
+})
+
+test('tracking parameters are still stripped with a permanent redirect', () => {
+  const response = request(
+    'https://iamsteve.me/blog/a-post?utm_source=x&keep=1'
+  )
+
+  assert.equal(response.status, 301)
+
+  const location = new URL(response.headers.get('location'))
+  assert.equal(location.searchParams.get('utm_source'), null)
+  assert.equal(location.searchParams.get('keep'), '1')
+})
+
+test('only the canonical host may be indexed', () => {
+  assert.equal(
+    request('https://preview.iamsteve.me/blog/a-post').headers.get(
+      'x-robots-tag'
+    ),
+    'noindex'
+  )
+  assert.equal(
+    request('https://iamsteve.me/blog/a-post').headers.get('x-robots-tag'),
+    null
+  )
+})
+
+test('files that answer for themselves are left alone', () => {
+  for (const path of [
+    '/.well-known/agent-skills/get-article-as-markdown/SKILL.md',
+    '/api/content/a-post',
+  ]) {
+    const response = request(`https://iamsteve.me${path}`, markdown)
+    assert.equal(response.status, 200, `${path} was intercepted`)
+    assert.equal(
+      response.headers.get('x-middleware-rewrite'),
+      null,
+      `${path} was rewritten`
+    )
+  }
+})

--- a/tests/register.mjs
+++ b/tests/register.mjs
@@ -1,0 +1,3 @@
+import { register } from 'node:module'
+
+register('./alias-hook.mjs', import.meta.url)

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,60 @@
 {
   "installCommand": "npm install -g pnpm && pnpm install",
-  "buildCommand": "pnpm run build"
+  "buildCommand": "pnpm run build",
+  "headers": [
+    {
+      "source": "/",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+        }
+      ]
+    },
+    {
+      "source": "/blog/:slug*",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+        }
+      ]
+    },
+    {
+      "source": "/notes/:slug*",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+        }
+      ]
+    },
+    {
+      "source": "/collections/:slug*",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+        }
+      ]
+    },
+    {
+      "source": "/about",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+        }
+      ]
+    },
+    {
+      "source": "/uses",
+      "headers": [
+        {
+          "key": "Vary",
+          "value": "Accept, RSC, Next-Router-State-Tree, Next-Router-Prefetch, Next-Router-Segment-Prefetch, Accept-Encoding"
+        }
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
Addresses the five findings from the agent readiness audit, plus two
defects the work uncovered.

Agent-friendly 404s
- 404 pages served an empty HTML shell that only filled in once JavaScript
  ran, because Next renders a client-side fallback when notFound() is thrown
  during a dynamic render. Declaring dynamicParams = false on the routes
  whose generateStaticParams already enumerates every renderable slug makes
  Next serve the prerendered not-found page instead.
- That page now lists where to look next: sitemap, llms.txt, the OpenAPI
  description, the API catalog, the archive and notes.
- A .md URL with no markdown representation answers 404 in markdown rather
  than HTML, and removed URLs answer 410 with the same pointers instead of
  an empty body.

Content without JavaScript
- Homepage cards sat at h2 under h2 section headings, so the outline was
  flat. Cards take a headingLevel and the homepage passes 3, leaving the
  listing pages, where cards sit under the page h1, unchanged.

OpenAPI
- Publishes an OpenAPI 3.1 description at /openapi.json covering the content,
  newsletter and discovery endpoints, linked from the API catalog via
  service-desc, the Link header, llms.txt and the markdown homepage.

JSON errors
- Every /api route answers failures with { error: { code, message, hint,
  status, documentation } }, and unknown /api paths hit a catch-all that
  answers in JSON instead of falling through to the HTML 404.

Vary
- Next overwrites Vary on page responses with its own RSC token list, so
  neither the proxy nor next.config can add Accept there. Markdown route
  handlers set Vary: Accept, Accept-Encoding themselves, and the CDN rules in
  netlify.toml and vercel.json add Accept to the negotiated HTML paths while
  keeping the RSC tokens.

Also fixed
- /about, /uses and /collections/* advertised markdown variants that rewrote
  to route handlers that did not exist, so they answered with an HTML 404.
  Added the missing handlers; the collections one serves the same listing the
  HTML page does.
- The markdown 404 initially swallowed the published SKILL.md files, so the
  proxy now leaves paths that answer for themselves alone.

Testing
- 30 node:test unit tests over the proxy, the recovery bodies, the error
  helper and the OpenAPI document, run by pnpm test and a CI workflow.
- scripts/verify-agent-endpoints.js checks every public endpoint and
  machine-readable file against a running server.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ne73QWscQqwgkvsCHtiMJf