### PR TITLE
Show collection titles from config on collections index

### DIFF
--- a/app/(page)/collections/page.js
+++ b/app/(page)/collections/page.js
@@ -54,6 +54,14 @@ const getData = cache(async () => {
   }
 })
 
+// Get the proper title from collections config
+function getDisplayTitle(collection) {
+  const collectionConfig = collections.find(
+    (c) => c.slugAsParams === collection.toLowerCase()
+  )
+  return collectionConfig ? collectionConfig.title : collection
+}
+
 async function Collections() {
   const { groupedCollections, lastImportDate } = await getData()
 
@@ -64,7 +72,7 @@ async function Collections() {
         .map(([collection, items]) => (
           <div className="flex flex-col gap-4" key={collection}>
             <h2 className="flex justify-between text-xl md:text-3xl font-display font-variation-bold leading-none lowercase text-heading m-0 pt-2">
-              {collection}
+              {getDisplayTitle(collection)}
 
               <span className="text-cornflour-600">{items.length}</span>
             </h2>


### PR DESCRIPTION
The index page printed the raw frontmatter value as each group
heading, so the ten items tagged `ux-design` output the slug instead
of a name. Look the title up in the collections config, as the
collection detail page already does, and fall back to the raw value
for groups that have no config entry.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HxGRb2m9hzN2d1EnQy6zRi